### PR TITLE
Update default provider/model selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
                 <div class="config-section">
                     <h4>Transcription Provider</h4>
                     <select class="form-control" id="transcription-provider">
-                        <option value="" disabled selected>Select provider</option>
+                        <option value="" selected>Select provider</option>
                         <option value="openai">OpenAI Whisper</option>
                         <option value="local">Local Whisper (whisper.cpp)</option>
                         <option value="google">Google Speech-to-Text</option>
@@ -190,7 +190,7 @@
                 <div class="config-section">
                     <h4>Post-processing Provider</h4>
                     <select class="form-control" id="postprocess-provider">
-                        <option value="" disabled selected>Select provider</option>
+                        <option value="" selected>Select provider</option>
                         <option value="openai">OpenAI GPT</option>
                         <option value="google">Google Gemini</option>
                         <option value="openrouter">OpenRouter</option>
@@ -201,7 +201,7 @@
                     <div class="model-config">
                         <label class="form-label">Transcription Model</label>
                         <select class="form-control" id="transcription-model">
-                            <option value="" disabled selected>Select model</option>
+                            <option value="" selected>Select model</option>
                             <option value="whisper-1">Whisper-1 (Legacy) - Complete</option>
                             <option value="gpt-4o-mini-transcribe">GPT-4o Mini - Fast</option>
                             <option value="gpt-4o-transcribe">GPT-4o - High Precision</option>
@@ -250,7 +250,7 @@
                     <div class="model-config">
                         <label class="form-label">Post-processing Model</label>
                         <select class="form-control" id="postprocess-model">
-                            <option value="" disabled selected>Select model</option>
+                            <option value="" selected>Select model</option>
                             <option value="gpt-4o-mini">GPT-4o Mini (OpenAI)</option>
                             <option value="gpt-4o">GPT-4o (OpenAI)</option>
                             <option value="gpt-4.1">GPT-4.1 (OpenAI)</option>

--- a/note-transcribe-ai/app.js
+++ b/note-transcribe-ai/app.js
@@ -78,10 +78,10 @@ class NotesApp {
         
         // Configuración de proveedores
         this.config = {
-            transcriptionProvider: 'openai',
-            postprocessProvider: 'openai',
-            transcriptionModel: 'whisper-1',
-            postprocessModel: 'gpt-4o-mini',
+            transcriptionProvider: '',
+            postprocessProvider: '',
+            transcriptionModel: '',
+            postprocessModel: '',
             openaiApiKey: '',
             googleApiKey: '',
             // Configuración avanzada de post-procesamiento
@@ -306,8 +306,8 @@ class NotesApp {
     showConfigModal() {
         document.getElementById('transcription-provider').value = this.config.transcriptionProvider;
         document.getElementById('postprocess-provider').value = this.config.postprocessProvider;
-        document.getElementById('transcription-model').value = this.config.transcriptionModel || 'whisper-1';
-        document.getElementById('postprocess-model').value = this.config.postprocessModel || 'gpt-4o-mini';
+        document.getElementById('transcription-model').value = this.config.transcriptionModel || '';
+        document.getElementById('postprocess-model').value = this.config.postprocessModel || '';
         document.getElementById('openai-api-key').value = this.config.openaiApiKey;
         document.getElementById('google-api-key').value = this.config.googleApiKey || '';
         

--- a/note-transcribe-ai/index.html
+++ b/note-transcribe-ai/index.html
@@ -162,6 +162,7 @@
             <div class="config-section">
                 <h4>Proveedor de Transcripción</h4>
                 <select class="form-control" id="transcription-provider">
+                    <option value="" selected>Seleccionar proveedor</option>
                     <option value="openai">OpenAI Whisper</option>
                     <option value="google">Google Speech-to-Text</option>
                 </select>
@@ -169,6 +170,7 @@
             <div class="config-section">
                 <h4>Proveedor de Post-procesamiento</h4>
                 <select class="form-control" id="postprocess-provider">
+                    <option value="" selected>Seleccionar proveedor</option>
                     <option value="openai">OpenAI GPT</option>
                     <option value="google">Google Gemini</option>
                     <option value="openrouter">OpenRouter</option>
@@ -179,12 +181,14 @@
                 <div class="model-config">
                     <label class="form-label">Modelo de Transcripción</label>
                     <select class="form-control" id="transcription-model">
+                        <option value="" selected>Seleccionar modelo</option>
                         <option value="whisper-1">Whisper-1 (OpenAI)</option>
                     </select>
                 </div>
                 <div class="model-config">
                     <label class="form-label">Modelo de Post-procesamiento</label>
                     <select class="form-control" id="postprocess-model">
+                        <option value="" selected>Seleccionar modelo</option>
                         <option value="gpt-4o-mini">GPT-4o Mini (OpenAI)</option>
                         <option value="gpt-4o">GPT-4o (OpenAI)</option>
                         <option value="gpt-4.1">GPT-4.1 (OpenAI)</option>


### PR DESCRIPTION
## Summary
- make provider/model placeholder selectable in main UI
- make provider/model placeholder selectable in Spanish UI
- update Spanish app defaults to start blank

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686904d3cb28832e8a96d4d27fc7d5fa