### PR TITLE
Add visual marker for transcription insertion

### DIFF
--- a/app.js
+++ b/app.js
@@ -220,10 +220,17 @@ class NotesApp {
         editor.addEventListener('mouseup', () => {
             this.updateSelectedText();
         });
-        
+
         editor.addEventListener('keyup', () => {
             this.updateSelectedText();
         });
+
+        // Show insertion marker on click/touch
+        const showMarker = () => {
+            this.showInsertionMarker();
+        };
+        editor.addEventListener('click', showMarker);
+        editor.addEventListener('touchend', showMarker);
         
         // Título de nota
         document.getElementById('note-title').addEventListener('input', () => {
@@ -343,6 +350,31 @@ class NotesApp {
             this.updateAIButtonsState(true);
             console.log('No text selected, AI buttons disabled');
         }
+    }
+
+    // Show a marker where the next transcription will be inserted
+    showInsertionMarker() {
+        // Remove existing marker
+        const oldMarker = document.getElementById('insertion-marker');
+        if (oldMarker) oldMarker.remove();
+
+        const selection = window.getSelection();
+        if (!selection.rangeCount) return;
+
+        const range = selection.getRangeAt(0).cloneRange();
+        range.collapse(true);
+        const rect = range.getClientRects()[0];
+        if (!rect) return;
+
+        const editorContent = document.querySelector('.editor-content');
+        const editorRect = editorContent.getBoundingClientRect();
+
+        const marker = document.createElement('div');
+        marker.id = 'insertion-marker';
+        marker.className = 'insertion-marker';
+        marker.style.top = `${rect.top - editorRect.top + editorContent.scrollTop}px`;
+        marker.style.left = `${rect.left - editorRect.left + editorContent.scrollLeft}px`;
+        editorContent.appendChild(marker);
     }
     
     // Actualizar estado de botones de IA
@@ -1906,7 +1938,11 @@ class NotesApp {
         range.setEndAfter(textNode);
         selection.removeAllRanges();
         selection.addRange(range);
-        
+
+        // Remove insertion marker after inserting text
+        const marker = document.getElementById('insertion-marker');
+        if (marker) marker.remove();
+
         // Disparar evento de cambio
         this.handleEditorChange();
         
@@ -2998,6 +3034,7 @@ document.addEventListener('selectionchange', () => {
             if (window.notesApp) {
                 window.notesApp.updateFormatButtons();
                 window.notesApp.updateSelectedText();
+                window.notesApp.showInsertionMarker();
             }
         }, 10);
     }

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>WhisPad - Smart Notes</title>
     <link rel="icon" type="image/png" href="logos/logo.png">
     <link rel="stylesheet" href="style.css">

--- a/style.css
+++ b/style.css
@@ -1113,6 +1113,7 @@ select.form-control {
     flex: 1;
     padding: var(--space-20);
     overflow-y: auto;
+    position: relative;
 }
 
 .editor {
@@ -1127,6 +1128,12 @@ select.form-control {
     background: transparent;
     resize: none;
     min-height: 300px;
+}
+
+@media (max-width: 768px) {
+    .editor {
+        font-size: 16px;
+    }
 }
 
 .editor:empty::before {
@@ -2128,4 +2135,16 @@ select.form-control {
 .upload-complete-message .message-text {
     color: var(--color-text);
     font-weight: 600;
+}
+
+/* Marker showing where transcriptions will be inserted */
+.insertion-marker {
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--color-primary);
+    pointer-events: none;
+    transform: translate(-50%, -50%);
+    z-index: 50;
 }


### PR DESCRIPTION
## Summary
- show a blue marker where the user clicks in the editor
- keep the marker when moving the caret and remove after inserting text
- style editor container as relative and add marker styling
- prevent zooming when focusing the editor on mobile devices
- make editor font larger on small screens to stop iOS zoom

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686915402524832eb0d22c77ceac5616