### PR TITLE
Fix OpenAI provider display and models

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ WhisPad is a transcription and note management tool designed so anyone can turn 
 - Automatic text enhancement using AI (OpenAI, Google or OpenRouter) with streaming responses.
 - A blue marker indicating where the transcription will be inserted.
 - Compatible with multiple providers: OpenAI, Google and local whisper.cpp (tiny model included on this repo, but you can download small, base, medium or large)
-- Ability to upload local (.bin) whisper.cpp models directly from the interface.
+- Download or upload local (.bin) whisper.cpp models directly from the interface.
 - Export all notes in a ZIP file with one click.
 - Mobile-friendly interface.
 
@@ -76,7 +76,7 @@ If you prefer not to use Docker, you can also run it directly with Python:
    ```bash
    bash install-whisper-cpp.sh
    ```
-   You can also upload your own `.bin` models from the interface.
+   You can also download or upload models from the interface.
 5. Run the server:
    ```bash
    python backend.py
@@ -95,7 +95,7 @@ Edit the `.env` file and fill in the variables `OPENAI_API_KEY`, `GOOGLE_API_KEY
 2. Select text fragments and apply style or clarity improvements with a click.
 3. Organize your notes: add titles, tags and search them easily.
 4. Download each note in Markdown or the entire set in a ZIP file.
-5. If you have local whisper.cpp models, upload them from the **Upload models** menu and enjoy offline transcription.
+5. Download additional whisper.cpp models from the **Models** menu (you can still drag and drop your own files) and enjoy offline transcription.
 6. Use the **Restore** menu to import previously saved notes.
 
 With these instructions you should have WhisPad running in just a few minutes with or without Docker. Enjoy fast transcription and all the benefits of organizing your ideas in one place!
@@ -113,7 +113,7 @@ Here are some screenshots of WhisPad in action:
 </p>
 
 <p align="center">
-  <img src="screenshots/screenshot3.png" alt="Upload models" width="700"/>
+  <img src="screenshots/screenshot3.png" alt="Manage whisper models" width="700"/>
 </p>
 
 <p align="center">

--- a/backend.py
+++ b/backend.py
@@ -49,7 +49,7 @@ def health_check():
 
 @app.route('/api/transcribe', methods=['POST'])
 def transcribe_audio():
-    """Endpoint para transcribir audio usando OpenAI Whisper o whisper.cpp local"""
+    """Endpoint para transcribir audio usando OpenAI o whisper.cpp local"""
     try:
         # Obtener el archivo de audio del request
         if 'audio' not in request.files:
@@ -1241,10 +1241,10 @@ def get_transcription_providers():
         if OPENAI_API_KEY:
             providers.append({
                 "id": "openai",
-                "name": "OpenAI Whisper",
-                "description": "Cloud-based transcription using OpenAI's Whisper API",
+                "name": "OpenAI",
+                "description": "Cloud-based transcription using OpenAI's API",
                 "available": True,
-                "models": ["whisper-1"]
+                "models": ["whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"]
             })
         
         # Verificar whisper.cpp local

--- a/backend.py
+++ b/backend.py
@@ -1191,6 +1191,50 @@ def upload_model():
     except Exception as e:
         return jsonify({"error": f"Error al subir modelo: {str(e)}"}), 500
 
+@app.route('/api/download-model', methods=['POST'])
+def download_model():
+    """Download a whisper.cpp model from the internet with progress via SSE"""
+    data = request.get_json() or {}
+    size = data.get('size')
+
+    MODEL_URLS = {
+        'tiny':   'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin',
+        'base':   'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin',
+        'small':  'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin',
+        'medium': 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin',
+        'large':  'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large.bin',
+    }
+
+    if size not in MODEL_URLS:
+        return jsonify({"error": "Modelo no válido"}), 400
+
+    url = MODEL_URLS[size]
+
+    def generate():
+        try:
+            models_dir = os.path.join(os.getcwd(), 'whisper-cpp-models')
+            os.makedirs(models_dir, exist_ok=True)
+            filename = os.path.join(models_dir, os.path.basename(url))
+
+            with requests.get(url, stream=True) as r:
+                r.raise_for_status()
+                total = int(r.headers.get('Content-Length', 0))
+                downloaded = 0
+                with open(filename, 'wb') as f:
+                    for chunk in r.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+                            downloaded += len(chunk)
+                            if total:
+                                progress = int(downloaded * 100 / total)
+                                yield f"data: {json.dumps({'progress': progress})}\n\n"
+
+            yield f"data: {json.dumps({'done': True, 'filename': os.path.basename(filename)})}\n\n"
+        except Exception as e:
+            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+
+    return Response(generate(), mimetype='text/event-stream', headers={'Cache-Control': 'no-cache'})
+
 @app.route('/api/get-note', methods=['GET'])
 def get_note():
     """Devuelve el contenido de una nota especificada por ID o nombre de archivo"""

--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
             <button class="btn btn--outline btn--sm" id="restore-btn" title="Restore notes from files">
                 <i class="fas fa-upload"></i>&nbsp;Restore
             </button>
-            <button class="btn btn--outline btn--sm" id="upload-models-btn" title="Upload whisper.cpp models">
-                <i class="fas fa-upload"></i>&nbsp;Upload models
+            <button class="btn btn--outline btn--sm" id="upload-models-btn" title="Manage whisper.cpp models">
+                <i class="fas fa-download"></i>&nbsp;Models
             </button>
             <button class="hamburger-menu" id="hamburger-menu" aria-label="Show/Hide notes menu">
                 <span></span><span></span><span></span>
@@ -373,17 +373,24 @@
         </div>
     </div>
 
-    <!-- Upload models modal -->
+    <!-- Download/Upload models modal -->
     <div class="modal" id="upload-model-modal">
         <div class="modal-content">
-            <h3>Upload Models</h3>
-            <p>Drag and drop .bin model files below or click the area to select</p>
+            <h3>Manage Whisper Models</h3>
+            <p>Select a model to download or drop your own .bin files below</p>
+            <div class="model-btns">
+                <button class="btn btn--secondary model-download" data-size="tiny">Tiny</button>
+                <button class="btn btn--secondary model-download" data-size="base">Base</button>
+                <button class="btn btn--secondary model-download" data-size="small">Small</button>
+                <button class="btn btn--secondary model-download" data-size="medium">Medium</button>
+                <button class="btn btn--secondary model-download" data-size="large">Large</button>
+            </div>
             <div class="drop-zone" id="upload-model-drop-zone">Drop files here</div>
             <input type="file" id="upload-model-file-input" multiple accept=".bin" style="display:none">
             
             <!-- Progress section -->
             <div class="upload-progress-section" id="upload-progress-section" style="display:none;">
-                <h4>Upload Progress</h4>
+                <h4>Progress</h4>
                 <div class="file-upload-list" id="file-upload-list"></div>
             </div>
             

--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
                     <h4>Transcription Provider</h4>
                     <select class="form-control" id="transcription-provider">
                         <option value="" selected>Select provider</option>
-                        <option value="openai">OpenAI Whisper</option>
+                        <option value="openai">OpenAI</option>
                         <option value="local">Local Whisper (whisper.cpp)</option>
                         <option value="google">Google Speech-to-Text</option>
                     </select>

--- a/note-transcribe-ai/index.html
+++ b/note-transcribe-ai/index.html
@@ -163,7 +163,7 @@
                 <h4>Proveedor de Transcripción</h4>
                 <select class="form-control" id="transcription-provider">
                     <option value="" selected>Seleccionar proveedor</option>
-                    <option value="openai">OpenAI Whisper</option>
+                    <option value="openai">OpenAI</option>
                     <option value="google">Google Speech-to-Text</option>
                 </select>
             </div>
@@ -183,6 +183,8 @@
                     <select class="form-control" id="transcription-model">
                         <option value="" selected>Seleccionar modelo</option>
                         <option value="whisper-1">Whisper-1 (OpenAI)</option>
+                        <option value="gpt-4o-mini-transcribe">GPT-4o Mini - Fast</option>
+                        <option value="gpt-4o-transcribe">GPT-4o - High Precision</option>
                     </select>
                 </div>
                 <div class="model-config">

--- a/style.css
+++ b/style.css
@@ -1287,6 +1287,14 @@ select.form-control {
     background-color: var(--color-surface);
 }
 
+/* Model download buttons */
+.model-btns {
+    display: flex;
+    gap: var(--space-8);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-16);
+}
+
 /* Processing overlay */
 .processing-overlay {
     display: none;


### PR DESCRIPTION
## Summary
- rename provider label from **OpenAI Whisper** to **OpenAI**
- expose GPT‑4o transcription models from the backend
- list GPT‑4o models in the note-taking demo

## Testing
- `python -m py_compile backend.py`


------
https://chatgpt.com/codex/tasks/task_e_68693766a154832e8b0e563dd886cd78