### PR TITLE
Enable HTTPS access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     git \
     curl \
     ffmpeg \
+    openssl \
     && rm -rf /var/lib/apt/lists/*
 
 # Crear directorio de trabajo

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you are not comfortable with the terminal, the easiest method is to use **Doc
    ```bash
    docker compose up
    ```
-4. Docker will download the dependencies and show *"Starting services..."*. When everything is ready, open your browser at `http://localhost:5037`.
+4. Docker will download the dependencies and show *"Starting services..."*. When everything is ready, open your browser at `https://localhost:5037`.
 5. To stop the application, press `Ctrl+C` in the terminal or use the *Stop* button in Docker Desktop.
 
 ## Installing with Docker Desktop
@@ -56,7 +56,7 @@ This option is ideal if you don't want to worry about installing Python or depen
    ```bash
    docker compose up
    ```
-4. Go to `http://localhost:5037` and start using WhisPad.
+4. Go to `https://localhost:5037` and start using WhisPad.
 5. To stop it, press `Ctrl+C` in the terminal or run `docker compose down`.
 
 ## Installing from the Terminal
@@ -81,7 +81,7 @@ If you prefer not to use Docker, you can also run it directly with Python:
    ```bash
    python backend.py
    ```
-6. Open `index.html` in your browser or serve the folder with `python -m http.server 5037` and visit `http://localhost:5037`.
+6. Open `index.html` in your browser or serve the folder with `python -m http.server 5037` and visit `https://localhost:5037`.
 
 ## API Key Configuration
 Copy `env.example` to `.env` and add your API keys:

--- a/backend.py
+++ b/backend.py
@@ -23,7 +23,7 @@ app.config['MAX_CONTENT_LENGTH'] = 4 * 1024 * 1024 * 1024  # 4GB
 app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0  # Disable caching for development
 
 # Configurar CORS para permitir acceso desde el frontend
-cors_origins = os.getenv('CORS_ORIGINS', 'http://localhost:3000,http://127.0.0.1:3000,http://localhost:5037').split(',')
+cors_origins = os.getenv('CORS_ORIGINS', 'http://localhost:3000,http://127.0.0.1:3000,https://localhost:5037').split(',')
 CORS(app, origins=cors_origins)
 
 # Configuración de APIs

--- a/capture_js_logs.py
+++ b/capture_js_logs.py
@@ -19,7 +19,7 @@ def simulate_javascript_execution():
         
         # Paso 2: Cargar audio como lo hace el JavaScript
         print("📁 Cargando archivo de audio...")
-        response = requests.get("http://localhost:5037/test/test.wav")
+        response = requests.get("https://localhost:5037/test/test.wav", verify=False)
         if not response.ok:
             raise Exception(f"No se pudo cargar test.wav: {response.status_code}")
         
@@ -81,7 +81,7 @@ def simulate_javascript_execution():
                 
                 # Hacer la petición EXACTA que hace el JavaScript
                 api_response = requests.post(
-                    "http://localhost:5037/api/transcribe-gpt4o",
+                    "https://localhost:5037/api/transcribe-gpt4o",
                     files=files,
                     data=data,
                     timeout=30
@@ -130,7 +130,7 @@ def analyze_potential_frontend_issues():
     # 1. Verificar si backend-api.js se carga correctamente
     print("1. Verificando backend-api.js...")
     try:
-        response = requests.get("http://localhost:5037/backend-api.js")
+        response = requests.get("https://localhost:5037/backend-api.js", verify=False)
         if response.ok:
             print("✅ backend-api.js accesible")
             
@@ -154,7 +154,7 @@ def analyze_potential_frontend_issues():
     # 2. Verificar página principal
     print("\n2. Verificando página principal...")
     try:
-        response = requests.get("http://localhost:5037/")
+        response = requests.get("https://localhost:5037/", verify=False)
         if response.ok:
             print("✅ Página principal accesible")
             
@@ -176,7 +176,7 @@ def analyze_potential_frontend_issues():
     # 3. Verificar headers CORS
     print("\n3. Verificando CORS...")
     try:
-        response = requests.get("http://localhost:5037/api/check-apis")
+        response = requests.get("https://localhost:5037/api/check-apis", verify=False)
         cors_headers = {k: v for k, v in response.headers.items() if 'cors' in k.lower() or 'access-control' in k.lower()}
         if cors_headers:
             print(f"✅ Headers CORS encontrados: {cors_headers}")
@@ -207,7 +207,7 @@ def main():
         print("🎯 Se encontraron problemas reales en el backend/API")
     
     print("\n📋 RECOMENDACIÓN:")
-    print("1. Abre http://localhost:5037/final_test.html en el navegador")
+    print("1. Abre https://localhost:5037/final_test.html en el navegador")
     print("2. Abre DevTools (F12)")
     print("3. Ve a la pestaña Console")
     print("4. Haz clic en 'Test Exacto del Frontend Principal'")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY:-}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - BACKEND_PORT=8000
-      - CORS_ORIGINS=http://localhost:5037,http://127.0.0.1:5037
+      - CORS_ORIGINS=https://localhost:5037,https://127.0.0.1:5037
       - DEBUG=False
     volumes:
       - ./logs:/var/log/nginx
@@ -18,7 +18,7 @@ services:
       - ./whisper-cpp-models:/app/whisper-cpp-models
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5037/health"]
+      test: ["CMD", "curl", "-k", "-f", "https://localhost:5037/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/env.example
+++ b/env.example
@@ -9,7 +9,7 @@ OPENROUTER_API_KEY=tu_openrouter_api_key_aqui
 
 # Configuración del backend
 BACKEND_PORT=8000
-CORS_ORIGINS=http://localhost:5037,http://127.0.0.1:5037
+CORS_ORIGINS=https://localhost:5037,https://127.0.0.1:5037
 
 # Configuración de la aplicación
 DEBUG=False

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,9 @@
 server {
-    listen 5037;
+    listen 5037 ssl;
     server_name localhost;
+
+    ssl_certificate     /etc/nginx/certs/selfsigned.crt;
+    ssl_certificate_key /etc/nginx/certs/selfsigned.key;
     
     # Configuración básica
     client_max_body_size 4G;  # Para subida de archivos de audio y modelos grandes

--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,16 @@ echo "Iniciando servicios..."
 mkdir -p /var/log/nginx
 mkdir -p /var/lib/nginx
 
+# Generar certificado SSL autofirmado si no existe
+if [ ! -f /etc/nginx/certs/selfsigned.crt ]; then
+    echo "Generando certificado SSL autofirmado..."
+    mkdir -p /etc/nginx/certs
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+        -keyout /etc/nginx/certs/selfsigned.key \
+        -out /etc/nginx/certs/selfsigned.crt \
+        -subj "/CN=localhost"
+fi
+
 # Crear y configurar directorio para notas guardadas
 mkdir -p /app/saved_notes
 chmod 777 /app/saved_notes


### PR DESCRIPTION
## Summary
- install `openssl` in the container image
- generate a self‑signed certificate at startup
- serve the site via HTTPS through nginx
- update CORS settings and healthcheck URL
- document HTTPS access instructions

## Testing
- `python -m py_compile backend.py capture_js_logs.py`

------
https://chatgpt.com/codex/tasks/task_e_68694443b100832e89b627dc5abef0bf