### PR TITLE
Relax whisper.cpp local model check

### DIFF
--- a/app.js
+++ b/app.js
@@ -1887,9 +1887,9 @@ class NotesApp {
             console.log('Language:', this.config.transcriptionLanguage);
             
             const result = await backendAPI.transcribeAudio(
-                audioBlob, 
-                this.config.transcriptionLanguage, 
-                'whisper-tiny-local',
+                audioBlob,
+                this.config.transcriptionLanguage,
+                this.config.transcriptionModel,
                 'local'
             );
             
@@ -2989,9 +2989,6 @@ class NotesApp {
         // Fallbacks for known providers
         if (provider === 'openai' && models.length === 0) {
             models = ['whisper-1', 'gpt-4o-mini-transcribe', 'gpt-4o-transcribe'];
-        }
-        if (provider === 'local' && models.length === 0) {
-            models = ['whisper-tiny-local'];
         }
         if (provider === 'google' && models.length === 0) {
             models = ['google-speech-to-text'];

--- a/backend.py
+++ b/backend.py
@@ -62,6 +62,7 @@ def transcribe_audio():
         # Obtener parámetros del request
         language = request.form.get('language', None)  # None = detección automática
         provider = request.form.get('provider', 'openai')  # openai o local
+        model_name = request.form.get('model')
         
         # Verificar disponibilidad del proveedor
         if provider == 'local':
@@ -70,10 +71,17 @@ def transcribe_audio():
             
             # Usar whisper.cpp local
             audio_bytes = audio_file.read()
+
+            model_path = None
+            if model_name:
+                models_dir = os.path.join(os.getcwd(), 'whisper-cpp-models')
+                model_path = os.path.join(models_dir, os.path.basename(model_name))
+
             result = whisper_wrapper.transcribe_audio_from_bytes(
-                audio_bytes, 
+                audio_bytes,
                 audio_file.filename,
-                language
+                language,
+                model_path
             )
             
             if result.get('success'):


### PR DESCRIPTION
## Summary
- loosen whisper.cpp wrapper prerequisites so only the executable is required
- support specifying a model path when transcribing
- use chosen model for local transcription in frontend
- remove fallback model when no local models are present
- backend passes chosen model file to whisper.cpp

## Testing
- `python -m py_compile backend.py whisper_cpp_wrapper.py`

------
https://chatgpt.com/codex/tasks/task_e_6869487fe638832ea123d75825edbcae