### PR TITLE
Add mobile floating record button

### DIFF
--- a/app.js
+++ b/app.js
@@ -221,9 +221,11 @@ class NotesApp {
         });
         const mobileFab = document.getElementById('mobile-record-fab');
         if (mobileFab) {
-            mobileFab.addEventListener('click', () => {
+            const handleMobileFab = () => {
                 this.toggleRecording();
-            });
+            };
+            mobileFab.addEventListener('click', handleMobileFab);
+            mobileFab.addEventListener('touchstart', handleMobileFab);
         }
         
         // Botones de IA - Se configurarán dinámicamente con updateAIButtons()

--- a/app.js
+++ b/app.js
@@ -99,7 +99,8 @@ class NotesApp {
             temperature: 0.3,
             maxTokens: 1000,
             topP: 0.95,
-            responseStyle: 'balanced'
+            responseStyle: 'balanced',
+            showMobileRecordButton: true
         };
         
         // Visible styles configuration
@@ -127,6 +128,7 @@ class NotesApp {
         // Sidebar responsive: cerrar en móvil por defecto
         this.setupSidebarResponsive();
         this.setupMobileHeaderActions();
+        this.updateMobileFabVisibility();
 
         // Migrate existing notes without ID
         await this.migrateExistingNotes();
@@ -199,7 +201,11 @@ class NotesApp {
         };
 
         moveButtons();
-        window.addEventListener('resize', moveButtons);
+        this.updateMobileFabVisibility();
+        window.addEventListener('resize', () => {
+            moveButtons();
+            this.updateMobileFabVisibility();
+        });
     }
     
     // Configurar event listeners
@@ -528,6 +534,7 @@ class NotesApp {
         const maxTokens = parseInt(document.getElementById('max-tokens').value);
         const topP = parseFloat(document.getElementById('top-p-range').value);
         const responseStyle = document.getElementById('response-style').value;
+        const showMobileRecordButton = document.getElementById('show-mobile-record').checked;
 
         this.config = {
             ...this.config, // Mantener otras configuraciones como API keys del .env
@@ -541,10 +548,12 @@ class NotesApp {
             temperature,
             maxTokens,
             topP,
-            responseStyle
+            responseStyle,
+            showMobileRecordButton
         };
 
         localStorage.setItem('notes-app-config', JSON.stringify(this.config));
+        this.updateMobileFabVisibility();
         this.hideConfigModal();
         this.showNotification('Configuration saved');
     }
@@ -565,6 +574,7 @@ class NotesApp {
         document.getElementById('max-tokens').value = this.config.maxTokens || 1000;
         document.getElementById('top-p-range').value = this.config.topP || 0.95;
         document.getElementById('response-style').value = this.config.responseStyle || 'balanced';
+        document.getElementById('show-mobile-record').checked = this.config.showMobileRecordButton !== false;
         
         // Actualizar valores mostrados
         this.updateRangeValues();
@@ -3123,6 +3133,14 @@ class NotesApp {
             document.getElementById('streaming-enabled').checked = false;
             document.getElementById('transcription-prompt').value = '';
         }
+    }
+
+    updateMobileFabVisibility() {
+        const mobileFab = document.getElementById('mobile-record-fab');
+        if (!mobileFab) return;
+
+        const shouldShow = this.config.showMobileRecordButton !== false && window.innerWidth <= 768;
+        mobileFab.classList.toggle('hidden', !shouldShow);
     }
 }
 

--- a/app.js
+++ b/app.js
@@ -77,6 +77,7 @@ class NotesApp {
         this.searchTerm = '';
         this.selectedText = '';
         this.selectedRange = null;
+        this.insertionRange = null;
         this.mediaRecorder = null;
         this.audioChunks = [];
         
@@ -218,6 +219,12 @@ class NotesApp {
         document.getElementById('record-btn').addEventListener('click', () => {
             this.toggleRecording();
         });
+        const mobileFab = document.getElementById('mobile-record-fab');
+        if (mobileFab) {
+            mobileFab.addEventListener('click', () => {
+                this.toggleRecording();
+            });
+        }
         
         // Botones de IA - Se configurarán dinámicamente con updateAIButtons()
         // document.querySelectorAll('.ai-btn').forEach(btn => {
@@ -367,6 +374,7 @@ class NotesApp {
         
         if (this.selectedText && selection.rangeCount > 0) {
             this.selectedRange = selection.getRangeAt(0).cloneRange();
+            this.insertionRange = this.selectedRange.cloneRange();
             this.updateAIButtonsState(false);
             console.log('Text selected, AI buttons enabled');
         } else {
@@ -387,6 +395,7 @@ class NotesApp {
 
         const range = selection.getRangeAt(0).cloneRange();
         range.collapse(true);
+        this.insertionRange = range.cloneRange();
         const rect = range.getClientRects()[0];
         if (!rect) return;
 
@@ -1799,12 +1808,17 @@ class NotesApp {
             const recordBtn = document.getElementById('record-btn');
             const recordIcon = document.getElementById('record-icon');
             const recordText = document.getElementById('record-text');
+            const mobileFab = document.getElementById('mobile-record-fab');
             const recordingStatus = document.getElementById('recording-status');
             const recordingIndicator = document.getElementById('recording-indicator');
             
             recordBtn.classList.add('btn--error');
             recordIcon.className = 'fas fa-stop';
             recordText.textContent = 'Stop';
+            if (mobileFab) {
+                mobileFab.classList.add('btn--error');
+                mobileFab.innerHTML = '<i class="fas fa-stop"></i>';
+            }
             recordingStatus.querySelector('.status-text').textContent = 'Recording...';
             recordingIndicator.classList.add('active');
 
@@ -1822,12 +1836,17 @@ class NotesApp {
             const recordBtn = document.getElementById('record-btn');
             const recordIcon = document.getElementById('record-icon');
             const recordText = document.getElementById('record-text');
+            const mobileFab = document.getElementById('mobile-record-fab');
             const recordingStatus = document.getElementById('recording-status');
             const recordingIndicator = document.getElementById('recording-indicator');
             
             recordBtn.classList.remove('btn--error');
             recordIcon.className = 'fas fa-microphone';
             recordText.textContent = 'Record';
+            if (mobileFab) {
+                mobileFab.classList.remove('btn--error');
+                mobileFab.innerHTML = '<i class="fas fa-microphone"></i>';
+            }
             recordingStatus.querySelector('.status-text').textContent = 'Processing...';
             recordingIndicator.classList.remove('active');
         }
@@ -2006,9 +2025,12 @@ class NotesApp {
         // Obtener posición del cursor o insertar al final
         const selection = window.getSelection();
         let range;
-        
+
         if (selection.rangeCount > 0) {
             range = selection.getRangeAt(0);
+            this.insertionRange = range.cloneRange();
+        } else if (this.insertionRange) {
+            range = this.insertionRange.cloneRange();
         } else {
             range = document.createRange();
             range.selectNodeContents(editor);
@@ -2022,6 +2044,7 @@ class NotesApp {
         range.setEndAfter(textNode);
         selection.removeAllRanges();
         selection.addRange(range);
+        this.insertionRange = range.cloneRange();
 
         // Remove insertion marker after inserting text
         const marker = document.getElementById('insertion-marker');

--- a/index.html
+++ b/index.html
@@ -400,7 +400,7 @@
         </div>
     </div>
 
-    <button id="mobile-record-fab" class="mobile-fab">
+    <button id="mobile-record-fab" class="mobile-fab" aria-label="Record">
         <i class="fas fa-microphone"></i>
     </button>
     <script src="backend-api.js"></script>

--- a/index.html
+++ b/index.html
@@ -400,6 +400,9 @@
         </div>
     </div>
 
+    <button id="mobile-record-fab" class="mobile-fab">
+        <i class="fas fa-microphone"></i>
+    </button>
     <script src="backend-api.js"></script>
     <script src="app.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -301,6 +301,16 @@
                         </div>
                     </div>
                 </div>
+                <div class="config-section">
+                    <h4>Interface Options</h4>
+                    <div class="checkbox-group">
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="show-mobile-record" checked>
+                            <span class="checkmark"></span>
+                            Show floating record button on mobile
+                        </label>
+                    </div>
+                </div>
             </div>
             <div class="modal-actions">
                 <button class="btn btn--outline" id="cancel-config">Cancel</button>

--- a/style.css
+++ b/style.css
@@ -2181,7 +2181,8 @@ select.form-control {
 #mobile-record-fab {
     position: fixed;
     bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
-    right: 16px;
+    left: 50%;
+    transform: translateX(-50%);
     width: 56px;
     height: 56px;
     border-radius: 50%;

--- a/style.css
+++ b/style.css
@@ -2176,3 +2176,31 @@ select.form-control {
     transform: translate(-50%, -50%);
     z-index: 50;
 }
+
+/* Floating record button shown only on mobile */
+#mobile-record-fab {
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background-color: var(--color-primary);
+    color: #fff;
+    border: none;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    z-index: 100;
+}
+
+#mobile-record-fab.btn--error {
+    background-color: var(--color-error);
+}
+
+@media (max-width: 768px) {
+    #mobile-record-fab {
+        display: flex;
+    }
+}

--- a/style.css
+++ b/style.css
@@ -2180,7 +2180,7 @@ select.form-control {
 /* Floating record button shown only on mobile */
 #mobile-record-fab {
     position: fixed;
-    bottom: 16px;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
     right: 16px;
     width: 56px;
     height: 56px;
@@ -2192,7 +2192,9 @@ select.form-control {
     align-items: center;
     justify-content: center;
     font-size: 24px;
-    z-index: 100;
+    z-index: 1100;
+    pointer-events: auto;
+    touch-action: manipulation;
 }
 
 #mobile-record-fab.btn--error {


### PR DESCRIPTION
## Summary
- add floating record button for mobile
- update JS to toggle recording from floating button
- store insertion range for mobile cursor position
- ensure UI icons sync on mobile

## Testing
- `python -m py_compile backend.py`
- `node -c app.js`


------
https://chatgpt.com/codex/tasks/task_e_6869520ca4b4832ebd32ba080c77d9e1