### PR TITLE
Add Flutter wrapper app

### DIFF
--- a/flutter_app/README.md
+++ b/flutter_app/README.md
@@ -1,0 +1,21 @@
+# WhisPad Flutter App
+
+Esta aplicación es un contenedor sencillo de la interfaz web de WhisPad. Permite introducir la URL del servidor y, opcionalmente, credenciales de autenticación basic (usuario y contraseña). Una vez conectados, se carga la interfaz web en un `WebView` y se pueden tomar notas y grabar audio igual que en la versión móvil del navegador.
+
+## Uso
+
+1. Instala Flutter en tu máquina siguiendo la documentación oficial.
+2. Ejecuta `flutter pub get` dentro de esta carpeta para descargar las dependencias.
+3. Conecta un dispositivo iOS o abre un simulador y ejecuta:
+
+```bash
+flutter run
+```
+
+Para generar un build de producción para iOS utiliza:
+
+```bash
+flutter build ios --release
+```
+
+Asegúrate de que en `ios/Runner/Info.plist` esté incluida la clave `NSMicrophoneUsageDescription` para permitir el acceso al micrófono.

--- a/flutter_app/ios/Runner/Info.plist
+++ b/flutter_app/ios/Runner/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>com.example.whispad</string>
+  <key>CFBundleName</key>
+  <string>WhisPad</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Necesitamos acceso al micrófono para grabar notas</string>
+</dict>
+</plist>

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  runApp(const WhisPadApp());
+}
+
+class WhisPadApp extends StatelessWidget {
+  const WhisPadApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'WhisPad',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const ConnectionScreen(),
+    );
+  }
+}
+
+class ConnectionScreen extends StatefulWidget {
+  const ConnectionScreen({super.key});
+
+  @override
+  State<ConnectionScreen> createState() => _ConnectionScreenState();
+}
+
+class _ConnectionScreenState extends State<ConnectionScreen> {
+  final TextEditingController _urlController = TextEditingController();
+  final TextEditingController _userController = TextEditingController();
+  final TextEditingController _passController = TextEditingController();
+
+  bool _connected = false;
+  WebViewController? _webViewController;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPrefs();
+  }
+
+  Future<void> _loadPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    _urlController.text = prefs.getString('url') ?? '';
+    _userController.text = prefs.getString('user') ?? '';
+    _passController.text = prefs.getString('pass') ?? '';
+  }
+
+  Future<void> _savePrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('url', _urlController.text);
+    await prefs.setString('user', _userController.text);
+    await prefs.setString('pass', _passController.text);
+  }
+
+  void _connect() async {
+    await _savePrefs();
+    setState(() {
+      _connected = true;
+    });
+  }
+
+  Widget _buildForm() {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: ListView(
+        children: [
+          TextField(
+            controller: _urlController,
+            decoration: const InputDecoration(labelText: 'URL del servidor'),
+          ),
+          TextField(
+            controller: _userController,
+            decoration: const InputDecoration(labelText: 'Usuario (opcional)'),
+          ),
+          TextField(
+            controller: _passController,
+            decoration: const InputDecoration(labelText: 'Contraseña (opcional)'),
+            obscureText: true,
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(onPressed: _connect, child: const Text('Conectar')),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_connected) {
+      return Scaffold(appBar: AppBar(title: const Text('WhisPad')), body: _buildForm());
+    }
+    return WebViewWidget(controller: _createController());
+  }
+
+  WebViewController _createController() {
+    final controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted);
+    final url = _urlController.text;
+    if (_userController.text.isNotEmpty || _passController.text.isNotEmpty) {
+      final auth = base64Encode(utf8.encode('${_userController.text}:${_passController.text}'));
+      controller.loadRequest(Uri.parse(url), headers: {'Authorization': 'Basic $auth'});
+    } else {
+      controller.loadRequest(Uri.parse(url));
+    }
+    _webViewController = controller;
+    return controller;
+  }
+}

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -1,0 +1,15 @@
+name: whispad_app
+description: Flutter wrapper for WhisPad web interface
+version: 1.0.0+1
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  webview_flutter: ^4.7.0
+  shared_preferences: ^2.2.0
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add a minimal Flutter project under `flutter_app`
- WebView-based wrapper loads the WhisPad server using optional basic auth
- include iOS plist with microphone permission
- add instructions for building the app

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b8c503fc0832e8ef441fb992fc034