### PR TITLE
Integrate SenseVoice provider

### DIFF
--- a/app.js
+++ b/app.js
@@ -1423,7 +1423,12 @@ class NotesApp {
 
     async downloadModelWithProgress(size, fileItem) {
         try {
-            const streamResponse = await backendAPI.downloadModelStream(size);
+            let streamResponse;
+            if (size === 'sensevoice-small') {
+                streamResponse = await backendAPI.downloadSenseVoiceModelStream();
+            } else {
+                streamResponse = await backendAPI.downloadModelStream(size);
+            }
             await backendAPI.processDownloadStream(streamResponse, percent => {
                 const progressBar = fileItem.querySelector('.progress-bar');
                 const progressPercentage = fileItem.querySelector('.progress-percentage');
@@ -1445,7 +1450,12 @@ class NotesApp {
         progressSection.style.display = 'block';
         fileUploadList.innerHTML = '';
 
-        const filename = `ggml-${size}.bin`;
+        let filename;
+        if (size === 'sensevoice-small') {
+            filename = 'sensevoice_small';
+        } else {
+            filename = `ggml-${size}.bin`;
+        }
         const fileItem = this.createFileUploadItem({ name: filename, size: 0 });
         fileUploadList.appendChild(fileItem);
 

--- a/backend-api.js
+++ b/backend-api.js
@@ -388,6 +388,19 @@ class BackendAPI {
         }
     }
 
+    async downloadSenseVoiceModelStream() {
+        try {
+            const response = await fetch(`${this.baseUrl}/api/download-sensevoice`, { method: 'POST' });
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            return response;
+        } catch (error) {
+            console.error('Error requesting SenseVoice model download:', error);
+            throw error;
+        }
+    }
+
     async processDownloadStream(streamResponse, onProgress = null) {
         try {
             const reader = streamResponse.body.getReader();

--- a/backend.py
+++ b/backend.py
@@ -115,7 +115,7 @@ def transcribe_audio():
                 return jsonify({
                     "transcription": result.get('transcription', ''),
                     "provider": "sensevoice",
-                    "model": result.get('model', 'SenseVoice Small')
+                    "model": result.get('model', 'sensevoice-small')
                 })
             else:
                 return jsonify({"error": f"Error en transcripción SenseVoice: {result.get('error', 'Unknown error')}"}), 500
@@ -1280,7 +1280,7 @@ def download_sensevoice_model():
                 success = sensevoice_wrapper.load_model()
                 if success:
                     yield f"data: {json.dumps({'progress': 100})}\n\n"
-                    yield f"data: {json.dumps({'done': True, 'filename': 'SenseVoiceSmall'})}\n\n"
+                    yield f"data: {json.dumps({'done': True, 'filename': 'sensevoice-small'})}\n\n"
                 else:
                     yield f"data: {json.dumps({'error': 'Failed to load model'})}\n\n"
             else:
@@ -1363,7 +1363,7 @@ def get_transcription_providers():
             providers.append({
                 "id": "sensevoice",
                 "name": "SenseVoice",
-                "description": "Local transcription using SenseVoice Small",
+                "description": "Local transcription using SenseVoice",
                 "available": True,
                 "models": ["sensevoice-small"],
                 "privacy": "Full privacy - no data leaves your device"

--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
                         <option value="openai">OpenAI</option>
                         <option value="local">Local Whisper (whisper.cpp)</option>
                         <option value="google">Google Speech-to-Text</option>
-                        <option value="sensevoice">SenseVoice Small</option>
+                        <option value="sensevoice">SenseVoice</option>
                     </select>
                     <small class="form-text text-muted">
                         Local Whisper provides complete privacy - no data leaves your device

--- a/index.html
+++ b/index.html
@@ -186,6 +186,7 @@
                         <option value="openai">OpenAI</option>
                         <option value="local">Local Whisper (whisper.cpp)</option>
                         <option value="google">Google Speech-to-Text</option>
+                        <option value="sensevoice">SenseVoice Small</option>
                     </select>
                     <small class="form-text text-muted">
                         Local Whisper provides complete privacy - no data leaves your device
@@ -230,6 +231,7 @@
                             <option value="ja">Japanese</option>
                             <option value="ko">Korean</option>
                             <option value="zh">Chinese</option>
+                            <option value="yue">Cantonese</option>
                             <option value="ar">Arabic</option>
                             <option value="hi">Hindi</option>
                             <option value="tr">Turkish</option>
@@ -389,7 +391,7 @@
     <!-- Download/Upload models modal -->
     <div class="modal" id="upload-model-modal">
         <div class="modal-content">
-            <h3>Manage Whisper Models</h3>
+            <h3>Manage Models</h3>
             <p>Select a model to download or drop your own .bin files below</p>
             <div class="model-btns">
                 <button class="btn btn--secondary model-download" data-size="tiny">Tiny</button>
@@ -397,6 +399,7 @@
                 <button class="btn btn--secondary model-download" data-size="small">Small</button>
                 <button class="btn btn--secondary model-download" data-size="medium">Medium</button>
                 <button class="btn btn--secondary model-download" data-size="large">Large</button>
+                <button class="btn btn--secondary model-download" data-size="sensevoice-small">SenseVoice Small</button>
             </div>
             <div class="drop-zone" id="upload-model-drop-zone">Drop files here</div>
             <input type="file" id="upload-model-file-input" multiple accept=".bin" style="display:none">
@@ -418,5 +421,4 @@
     </button>
     <script src="backend-api.js"></script>
     <script src="app.js"></script>
-</body>
-</html>
+</body></html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ python-dotenv
 pydub
 librosa
 soundfile
+funasr
+torch
+torchaudio
+huggingface_hub

--- a/sensevoice_wrapper.py
+++ b/sensevoice_wrapper.py
@@ -1,0 +1,73 @@
+import os
+import sys
+from io import BytesIO
+from typing import Optional, Dict, Any
+
+try:
+    import torchaudio
+    from funasr.utils.postprocess_utils import rich_transcription_postprocess
+    AUDIO_AVAILABLE = True
+except Exception as e:
+    print(f"Warning loading SenseVoice dependencies: {e}")
+    AUDIO_AVAILABLE = False
+
+class SenseVoiceWrapper:
+    """Wrapper for the SenseVoice Small model"""
+
+    def __init__(self, model_dir: str = "iic/SenseVoiceSmall", device: Optional[str] = None):
+        self.model_dir = model_dir
+        self.device = device or os.getenv("SENSEVOICE_DEVICE", "cpu")
+        self.model = None
+        self.kwargs = None
+        self._loaded = False
+        # add repo path for local code
+        repo_path = os.path.join(os.path.dirname(__file__), "SenseVoice-main")
+        if repo_path not in sys.path:
+            sys.path.append(repo_path)
+        try:
+            from model import SenseVoiceSmall
+            self.ModelClass = SenseVoiceSmall
+        except Exception as e:
+            print(f"Error importing SenseVoiceSmall: {e}")
+            self.ModelClass = None
+
+    def load_model(self) -> bool:
+        if not AUDIO_AVAILABLE or not self.ModelClass:
+            return False
+        if self._loaded:
+            return True
+        try:
+            self.model, self.kwargs = self.ModelClass.from_pretrained(model=self.model_dir, device=self.device)
+            self.model.eval()
+            self._loaded = True
+            return True
+        except Exception as e:
+            print(f"Error loading SenseVoice model: {e}")
+            return False
+
+    def is_ready(self) -> bool:
+        return self._loaded
+
+    def transcribe_audio_from_bytes(self, audio_bytes: bytes, language: Optional[str] = "auto") -> Dict[str, Any]:
+        if not self._loaded:
+            if not self.load_model():
+                return {"success": False, "error": "Model not loaded"}
+        try:
+            bio = BytesIO(audio_bytes)
+            waveform, fs = torchaudio.load(bio)
+            waveform = waveform.mean(0)
+            res = self.model.inference(
+                data_in=waveform,
+                language=language or "auto",
+                use_itn=False,
+                ban_emo_unk=False,
+                fs=fs,
+                **self.kwargs,
+            )
+            if not res or not res[0]:
+                return {"success": False, "error": "No result"}
+            text = res[0][0]["text"]
+            text = rich_transcription_postprocess(text)
+            return {"success": True, "transcription": text, "model": "SenseVoice Small"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}


### PR DESCRIPTION
## Summary
- implement `SenseVoiceWrapper` to run SenseVoice Small
- add SenseVoice as a transcription provider
- enable model download for SenseVoice
- expose new provider via frontend and add Cantonese option
- update dependencies for SenseVoice support

## Testing
- `python3 -m py_compile sensevoice_wrapper.py`
- `python3 -m py_compile backend.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eaf547e60832ea3a5f2af41dc3aab