### PR TITLE
Ensure SenseVoice model loads after download

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1298,6 +1298,7 @@ def download_sensevoice():
     """Download SenseVoice model from Hugging Face with progress via SSE"""
     try:
         def generate():
+            global sensevoice_wrapper, SENSEVOICE_AVAILABLE
             try:
                 # Import huggingface_hub here to avoid startup dependency
                 try:
@@ -1341,6 +1342,13 @@ def download_sensevoice():
                 )
                 
                 yield f"data: {json.dumps({'progress': 80})}\n\n"
+
+                # Update availability and preload model
+                SENSEVOICE_AVAILABLE = sensevoice_wrapper.is_available()
+                if SENSEVOICE_AVAILABLE:
+                    sensevoice_wrapper.model_loaded = False
+                    sensevoice_wrapper._load_model()
+
                 yield f"data: {json.dumps({'status': 'Download completed successfully!'})}\n\n"
                 yield f"data: {json.dumps({'progress': 100})}\n\n"
                 yield f"data: {json.dumps({'done': True, 'filename': 'SenseVoiceSmall', 'path': sensevoice_dir})}\n\n"


### PR DESCRIPTION
## Summary
- update `/api/download-sensevoice` to set `SENSEVOICE_AVAILABLE`
- preload the SenseVoice model right after finishing download

## Testing
- `python -m py_compile backend.py sensevoice_wrapper.py test_sensevoice_direct.py`
- `node test_sensevoice_frontend.js`


------
https://chatgpt.com/codex/tasks/task_e_686f70f53008832ea19cedce7d8b7262