### PR TITLE
Fix SenseVoice availability check

### DIFF
--- a/sensevoice_wrapper.py
+++ b/sensevoice_wrapper.py
@@ -90,16 +90,8 @@ class SenseVoiceWrapper:
                             print(f"SenseVoice model found at: {model_dir}")
                             return True
             
-            # Try to check if FunASR can load the model using standard identifiers
-            try:
-                # This will check if the model can be loaded via FunASR without actually loading it
-                result = self._can_load_via_funasr()
-                if result:
-                    print("SenseVoice model available via FunASR")
-                return result
-            except:
-                pass
-                
+            # If model not found locally, do not expose the provider
+            # (behave like local Whisper models)
             print("SenseVoice model not found in any location")
             return False
         except Exception as e:


### PR DESCRIPTION
## Summary
- remove remote model check in `is_available`
- ensure SenseVoice isn't listed until files are local

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686fb12bc770832eb90093e9e795adc2