### PR TITLE
Add local providers Ollama and LM Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ WhisPad is a transcription and note management tool designed so anyone can turn 
 - Real-time voice-to-text transcription from the browser.
 - Write and edit markdown notes.
 - Integrated note manager: create, search, tag, save, restore and download in Markdown format.
-- Automatic text enhancement using AI (OpenAI, Google or OpenRouter) with streaming responses.
+- Automatic text enhancement using AI (OpenAI, Google, OpenRouter or local providers like Ollama and LM Studio) with streaming responses.
 - A blue marker indicating where the transcription will be inserted.
 - Compatible with multiple providers: OpenAI, Google, SenseVoice and local whisper.cpp. No model is bundled, but you can download tiny, small, base, medium or large versions from the interface.
 - **NEW: SenseVoice Integration** - Advanced multilingual speech recognition with emotion detection and audio event recognition for 50+ languages.
@@ -90,6 +90,7 @@ Copy `env.example` to `.env` and add your API keys:
 cp env.example .env
 ```
 Edit the `.env` file and fill in the variables `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `DEEPSEEK_API_KEY` and `OPENROUTER_API_KEY` for the services you want to use. These keys enable cloud transcription and text enhancement.
+If you plan to use local models through **Ollama** or **LM Studio**, also configure `OLLAMA_HOST`, `OLLAMA_PORT`, `LMSTUDIO_HOST` and `LMSTUDIO_PORT`.
 
 ## Usage Guide
 1. Press the microphone button to record audio and get real-time transcription.

--- a/env.example
+++ b/env.example
@@ -7,6 +7,12 @@ GOOGLE_API_KEY=tu_google_api_key_aqui
 DEEPSEEK_API_KEY=tu_deepseek_api_key_aqui
 OPENROUTER_API_KEY=tu_openrouter_api_key_aqui
 
+# Configuración de proveedores locales
+OLLAMA_HOST=localhost
+OLLAMA_PORT=11434
+LMSTUDIO_HOST=localhost
+LMSTUDIO_PORT=1234
+
 # Configuración del backend
 BACKEND_PORT=8000
 CORS_ORIGINS=https://localhost:5037,https://127.0.0.1:5037

--- a/index.html
+++ b/index.html
@@ -274,6 +274,8 @@
                         <option value="openai">OpenAI GPT</option>
                         <option value="google">Google Gemini</option>
                         <option value="openrouter">OpenRouter</option>
+                        <option value="ollama">Ollama</option>
+                        <option value="lmstudio">LM Studio</option>
                     </select>
                 </div>
                 <div class="config-section">

--- a/note-transcribe-ai/app.js
+++ b/note-transcribe-ai/app.js
@@ -84,6 +84,8 @@ class NotesApp {
             postprocessModel: '',
             openaiApiKey: '',
             googleApiKey: '',
+            ollamaUrl: '',
+            lmstudioUrl: '',
             // Configuración avanzada de post-procesamiento
             temperature: 0.3,
             maxTokens: 1000,
@@ -278,6 +280,8 @@ class NotesApp {
         const postprocessModel = document.getElementById('postprocess-model').value;
         const openaiApiKey = document.getElementById('openai-api-key').value;
         const googleApiKey = document.getElementById('google-api-key').value;
+        const ollamaUrl = document.getElementById('ollama-url').value;
+        const lmstudioUrl = document.getElementById('lmstudio-url').value;
         
         // Configuración avanzada
         const temperature = parseFloat(document.getElementById('temperature-range').value);
@@ -292,6 +296,8 @@ class NotesApp {
             postprocessModel,
             openaiApiKey,
             googleApiKey,
+            ollamaUrl,
+            lmstudioUrl,
             temperature,
             maxTokens,
             topP,
@@ -310,6 +316,8 @@ class NotesApp {
         document.getElementById('postprocess-model').value = this.config.postprocessModel || '';
         document.getElementById('openai-api-key').value = this.config.openaiApiKey;
         document.getElementById('google-api-key').value = this.config.googleApiKey || '';
+        document.getElementById('ollama-url').value = this.config.ollamaUrl || '';
+        document.getElementById('lmstudio-url').value = this.config.lmstudioUrl || '';
         
         // Configuración avanzada
         document.getElementById('temperature-range').value = this.config.temperature || 0.3;

--- a/note-transcribe-ai/backend-api.js
+++ b/note-transcribe-ai/backend-api.js
@@ -26,7 +26,7 @@ class BackendAPI {
             throw new Error('Error checking API status');
         } catch (error) {
             console.error('Error checking APIs:', error);
-            return { openai: false, google: false, deepseek: false, openrouter: false };
+            return { openai: false, google: false, deepseek: false, openrouter: false, ollama: true, lmstudio: true };
         }
     }
 
@@ -53,7 +53,7 @@ class BackendAPI {
         }
     }
 
-    async improveText(text, improvementType, provider = 'openai', stream = true, model = null) {
+    async improveText(text, improvementType, provider = 'openai', stream = true, model = null, customPrompt = null, host = null, port = null) {
         try {
             if (stream) {
                 return this.improveTextStream(text, improvementType, provider, model);
@@ -78,6 +78,11 @@ class BackendAPI {
             if (model) {
                 requestBody.model = model;
             }
+            if (customPrompt) {
+                requestBody.custom_prompt = customPrompt;
+            }
+            if (host) requestBody.host = host;
+            if (port) requestBody.port = port;
 
             const response = await fetch(`${this.baseUrl}/api/improve-text`, {
                 method: 'POST',
@@ -100,7 +105,7 @@ class BackendAPI {
         }
     }
 
-    async improveTextStream(text, improvementType, provider = 'openai', model = null) {
+    async improveTextStream(text, improvementType, provider = 'openai', model = null, customPrompt = null, host = null, port = null) {
         try {
             const requestBody = {
                 text: text,
@@ -112,6 +117,11 @@ class BackendAPI {
             if (model) {
                 requestBody.model = model;
             }
+            if (customPrompt) {
+                requestBody.custom_prompt = customPrompt;
+            }
+            if (host) requestBody.host = host;
+            if (port) requestBody.port = port;
 
             const response = await fetch(`${this.baseUrl}/api/improve-text`, {
                 method: 'POST',

--- a/note-transcribe-ai/index.html
+++ b/note-transcribe-ai/index.html
@@ -187,6 +187,8 @@
                         <option value="openai">OpenAI GPT</option>
                         <option value="google">Google Gemini</option>
                         <option value="openrouter">OpenRouter</option>
+                        <option value="ollama">Ollama</option>
+                        <option value="lmstudio">LM Studio</option>
                     </select>
                 </div>
                 <div class="config-section">
@@ -248,6 +250,14 @@
                     <div class="api-key-group">
                         <label class="form-label">Google AI API Key</label>
                         <input type="password" class="form-control" id="google-api-key" placeholder="AI...">
+                    </div>
+                    <div class="api-key-group">
+                        <label class="form-label">Ollama URL</label>
+                        <input type="text" class="form-control" id="ollama-url" placeholder="http://127.0.0.1:11434">
+                    </div>
+                    <div class="api-key-group">
+                        <label class="form-label">LM Studio URL</label>
+                        <input type="text" class="form-control" id="lmstudio-url" placeholder="http://127.0.0.1:1234">
                     </div>
                     <small>Tus API keys se guardan localmente en tu navegador</small>
                 </div>


### PR DESCRIPTION
## Summary
- support local Ollama/LM Studio providers for text improvement
- expose host/port settings through env variables and frontend config
- update API helpers and pages to handle new providers
- document new options in README

## Testing
- `pytest -q` *(fails: PyTorch, FunASR, soundfile, librosa, scipy, numpy missing)*

------
https://chatgpt.com/codex/tasks/task_e_686fb64bd08c832e9e481b0b38d6f81c