### PR TITLE
Fix note labels and handle missing AI config

### DIFF
--- a/app.js
+++ b/app.js
@@ -837,7 +837,7 @@ class NotesApp {
         const now = new Date();
         const newNote = {
             id: Date.now(),
-            title: `Nota ${now.toLocaleDateString()} ${now.toLocaleTimeString()}`,
+            title: `Note ${now.toLocaleDateString()} ${now.toLocaleTimeString()}`,
             content: '',
             createdAt: now.toISOString(),
             updatedAt: now.toISOString(),
@@ -2331,6 +2331,10 @@ class NotesApp {
         // Verificar configuración según el modelo seleccionado
         const provider = this.config.postprocessProvider;
         const model = this.config.postprocessModel;
+        if (!provider || !model) {
+            this.showNotification('Please, select a post-processing provider and model', 'error');
+            return;
+        }
         const isGemini = provider === 'google';
         const isOpenAI = provider === 'openai';
         const isOpenRouter = provider === 'openrouter';

--- a/app_1.js
+++ b/app_1.js
@@ -205,11 +205,11 @@ class NotesApp {
         if (saved) {
             this.notes = JSON.parse(saved);
         } else {
-            // Nota de ejemplo inicial
+            // Example note on first run
             this.notes = [{
                 id: 1,
-                title: "Nota de ejemplo",
-                content: "Esta es una nota de ejemplo para demostrar la funcionalidad de la aplicación. Puedes editarla, eliminarla o crear nuevas notas.",
+                title: "Example Note",
+                content: "This is a sample note to demonstrate the application's features. You can edit it, delete it or create new notes.",
                 createdAt: new Date().toISOString(),
                 updatedAt: new Date().toISOString()
             }];
@@ -225,7 +225,7 @@ class NotesApp {
         const now = new Date();
         const newNote = {
             id: Date.now(),
-            title: `Nota ${now.toLocaleDateString()} ${now.toLocaleTimeString()}`,
+            title: `Note ${now.toLocaleDateString()} ${now.toLocaleTimeString()}`,
             content: '',
             createdAt: now.toISOString(),
             updatedAt: now.toISOString()
@@ -304,7 +304,7 @@ class NotesApp {
         const title = document.getElementById('note-title').value.trim();
         const content = document.getElementById('editor').innerHTML;
         
-        this.currentNote.title = title || 'Nota sin título';
+        this.currentNote.title = title || 'Untitled Note';
         this.currentNote.content = content;
         this.currentNote.updatedAt = new Date().toISOString();
         
@@ -317,7 +317,7 @@ class NotesApp {
         this.saveNoteToServer(silent);
         
         if (!silent) {
-            this.showNotification('Nota guardada correctamente');
+            this.showNotification('Note saved successfully');
         }
     }
     
@@ -344,7 +344,7 @@ class NotesApp {
             const result = await response.json();
             
             if (!silent && result.success) {
-                console.log(`Nota guardada en servidor: ${result.filename}`);
+                console.log(`Note saved on server: ${result.filename}`);
             }
         } catch (error) {
             console.error('Error al guardar nota en servidor:', error);
@@ -370,7 +370,7 @@ class NotesApp {
         this.currentNote = null;
         this.setupDefaultNote();
         this.hideDeleteModal();
-        this.showNotification('Nota eliminada');
+        this.showNotification('Note deleted');
     }
     
     async deleteNoteFromServer(noteId) {

--- a/backend.py
+++ b/backend.py
@@ -803,7 +803,7 @@ def save_note():
         
         # Generar nombre de archivo seguro basado en el título
         if not title:
-            title = "Nota sin título"
+            title = "Untitled Note"
         
         safe_filename = generate_safe_filename(title)
         new_filename = f"{safe_filename}.md"

--- a/note-transcribe-ai/app.js
+++ b/note-transcribe-ai/app.js
@@ -251,11 +251,11 @@ class NotesApp {
         if (saved) {
             this.notes = JSON.parse(saved);
         } else {
-            // Nota de ejemplo inicial
+            // Example note on first run
             this.notes = [{
                 id: 1,
-                title: "Nota de ejemplo",
-                content: "Esta es una nota de ejemplo para demostrar la funcionalidad de la aplicación. Puedes editarla, eliminarla o crear nuevas notas.",
+                title: "Example Note",
+                content: "This is a sample note to demonstrate the application's features. You can edit it, delete it or create new notes.",
                 createdAt: new Date().toISOString(),
                 updatedAt: new Date().toISOString()
             }];
@@ -337,7 +337,7 @@ class NotesApp {
         const now = new Date();
         const newNote = {
             id: Date.now(),
-            title: `Nota ${now.toLocaleDateString()} ${now.toLocaleTimeString()}`,
+            title: `Note ${now.toLocaleDateString()} ${now.toLocaleTimeString()}`,
             content: '',
             createdAt: now.toISOString(),
             updatedAt: now.toISOString()
@@ -419,7 +419,7 @@ class NotesApp {
         const title = document.getElementById('note-title').value.trim();
         const content = document.getElementById('editor').innerHTML;
         
-        this.currentNote.title = title || 'Nota sin título';
+        this.currentNote.title = title || 'Untitled Note';
         this.currentNote.content = content;
         this.currentNote.updatedAt = new Date().toISOString();
         
@@ -432,7 +432,7 @@ class NotesApp {
         this.saveNoteToServer(silent);
         
         if (!silent) {
-            this.showNotification('Nota guardada correctamente');
+            this.showNotification('Note saved successfully');
         }
     }
     
@@ -459,7 +459,7 @@ class NotesApp {
             const result = await response.json();
             
             if (!silent && result.success) {
-                console.log(`Nota guardada en servidor: ${result.filename}`);
+                console.log(`Note saved on server: ${result.filename}`);
             }
         } catch (error) {
             console.error('Error al guardar nota en servidor:', error);
@@ -485,7 +485,7 @@ class NotesApp {
         this.currentNote = null;
         this.setupDefaultNote();
         this.hideDeleteModal();
-        this.showNotification('Nota eliminada');
+        this.showNotification('Note deleted');
     }
     
     async deleteNoteFromServer(noteId) {
@@ -721,10 +721,15 @@ class NotesApp {
             return;
         }
 
-        // Verificar configuración según el modelo seleccionado
-        const model = this.config.postprocessModel || 'gpt-4o-mini';
-        const isGemini = model.startsWith('gemini');
-        const isOpenAI = model.startsWith('gpt');
+        // Verify configuration
+        const provider = this.config.postprocessProvider;
+        const model = this.config.postprocessModel;
+        if (!provider || !model) {
+            this.showNotification('Please, select a post-processing provider and model', 'error');
+            return;
+        }
+        const isGemini = provider === 'google';
+        const isOpenAI = provider === 'openai';
 
         if (isOpenAI && !this.config.openaiApiKey) {
             this.showNotification('Please configure your OpenAI API key', 'warning');


### PR DESCRIPTION
## Summary
- translate Spanish note titles to English
- show error message if no AI post-processing model/provider selected
- update demo script note messages
- translate backend placeholder title

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686fd7a23b30832eaba51b4e3cbcb6c9