### PR TITLE
Add LM Studio dynamic options

### DIFF
--- a/app.js
+++ b/app.js
@@ -376,6 +376,13 @@ class NotesApp {
         document.getElementById('add-style-btn').addEventListener('click', () => {
             this.addNewStyle();
         });
+
+        const updateModelsBtn = document.getElementById('update-lmstudio-models-btn');
+        if (updateModelsBtn) {
+            updateModelsBtn.addEventListener('click', () => {
+                this.updateLmStudioModelsList();
+            });
+        }
         
         // Auto-guardado cada 30 segundos
         setInterval(() => {
@@ -640,6 +647,8 @@ class NotesApp {
         
         // Mostrar/ocultar opciones SenseVoice según el proveedor seleccionado
         this.toggleSenseVoiceOptions();
+        // Mostrar/ocultar opciones LM Studio según el proveedor seleccionado
+        this.toggleLmStudioOptions();
 
         const modal = document.getElementById('config-modal');
         this.hideMobileFab();
@@ -3281,6 +3290,7 @@ class NotesApp {
         if (postprocessProvider) {
             postprocessProvider.addEventListener('change', () => {
                 this.updateModelOptions();
+                this.toggleLmStudioOptions();
             });
         }
         
@@ -3490,6 +3500,23 @@ class NotesApp {
         } else {
             this.restoreDefaultLanguageOptions();
         }
+    }
+
+    toggleLmStudioOptions() {
+        const provider = document.getElementById('postprocess-provider').value;
+        const lmstudioOptions = document.getElementById('lmstudio-options');
+
+        if (lmstudioOptions) {
+            lmstudioOptions.style.display = provider === 'lmstudio' ? 'block' : 'none';
+        }
+    }
+
+    updateLmStudioModelsList() {
+        const modelsInput = document.getElementById('lmstudio-models');
+        if (!modelsInput) return;
+
+        this.config.lmstudioModels = modelsInput.value.trim();
+        this.updateModelOptions();
     }
 
     updateLanguageOptionsForSenseVoice() {

--- a/index.html
+++ b/index.html
@@ -325,7 +325,7 @@
                         <option value="gemini-2.0-flash">Gemini 2.0 Flash (Google)</option>
                     </select>
                 </div>
-                <div class="config-section">
+                <div class="config-section" id="lmstudio-options" style="display: none;">
                     <h5>LM Studio Server</h5>
                     <div class="api-key-group">
                         <label class="form-label">Host</label>
@@ -338,7 +338,8 @@
                     <div class="api-key-group">
                         <label class="form-label">Models (comma separated)</label>
                         <input type="text" class="form-control" id="lmstudio-models" placeholder="model-A,model-B">
-                    </div>
+                        <button class="btn btn--primary btn--sm" id="update-lmstudio-models-btn">Update Models</button>
+                </div>
                 </div>
                 <div class="config-section">
                     <h5>Advanced Post-processing Configuration</h5>


### PR DESCRIPTION
## Summary
- show LM Studio server settings only when LM Studio provider is chosen
- allow updating LM Studio models list without leaving the config modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_686feba8efa4832e8ad600636cec7194