### PR TITLE
Show downloaded models with delete option

### DIFF
--- a/backend-api.js
+++ b/backend-api.js
@@ -572,6 +572,36 @@ class BackendAPI {
             throw error;
         }
     }
+
+    async listModels() {
+        try {
+            const response = await fetch(`${this.baseUrl}/api/list-models`);
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            return await response.json();
+        } catch (error) {
+            console.error('Error listing models:', error);
+            throw error;
+        }
+    }
+
+    async deleteModel(name) {
+        try {
+            const response = await fetch(`${this.baseUrl}/api/delete-model`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name })
+            });
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            return await response.json();
+        } catch (error) {
+            console.error('Error deleting model:', error);
+            throw error;
+        }
+    }
     async refreshProviders() {
         try {
             const response = await fetch(`${this.baseUrl}/api/refresh-providers`, {

--- a/index.html
+++ b/index.html
@@ -492,6 +492,12 @@
                 <h4>Progress</h4>
                 <div class="file-upload-list" id="file-upload-list"></div>
             </div>
+
+            <!-- Downloaded models section -->
+            <div class="downloaded-models" id="downloaded-models-section" style="display:none;">
+                <h4>Downloaded Models</h4>
+                <ul class="model-list" id="downloaded-models-list"></ul>
+            </div>
             
             <div class="modal-actions">
                 <button class="btn btn--outline" id="cancel-upload-models">Close</button>

--- a/style.css
+++ b/style.css
@@ -2329,3 +2329,33 @@ select.form-control {
     font-size: var(--font-size-xs);
     margin: var(--space-4) var(--space-2);
 }
+
+/* Downloaded models list */
+.downloaded-models {
+    margin-top: var(--space-24);
+    border-top: 1px solid var(--color-border);
+    padding-top: var(--space-16);
+}
+
+.model-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.model-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--space-8) 0;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.model-item:last-child {
+    border-bottom: none;
+}
+
+.model-name {
+    font-size: var(--font-size-sm);
+    color: var(--color-text);
+}


### PR DESCRIPTION
## Summary
- list whisper models from backend with API endpoints
- support listing and deleting models in backend API wrapper
- show downloaded models in models modal and allow deletion
- style downloaded model list in modal

## Testing
- `python3 -m py_compile backend.py`
- `node --check app.js`
- `node --check backend-api.js`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686fee842c7c832eaf5a6d2715eaefd9