### PR TITLE
Fix nested f-string for older Python

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -805,7 +805,7 @@ def improve_text_ollama(text, improvement_type, model, host, port, custom_prompt
         else:
             return jsonify({"error": f"Ollama error {response.status_code}"}), response.status_code
     except requests.RequestException as e:
-        return jsonify({"error": f"Error de conexi\xF3n con Ollama: {str(e)}"}), 500
+        return jsonify({"error": f"Error de conexión con Ollama: {str(e)}"}), 500
     except Exception as e:
         return jsonify({"error": f"Error interno: {str(e)}"}), 500
 
@@ -859,7 +859,7 @@ def improve_text_ollama_stream(text, improvement_type, model, host, port, custom
                     except json.JSONDecodeError:
                         continue
         except requests.RequestException as e:
-            yield f"data: {json.dumps({'error': f'Error de conexi\xF3n con Ollama: {str(e)}'})}\n\n"
+            yield f"data: {json.dumps({'error': f'Error de conexión con Ollama: {str(e)}'})}\n\n"
         except Exception as e:
             yield f"data: {json.dumps({'error': f'Error interno: {str(e)}'})}\n\n"
 


### PR DESCRIPTION
## Summary
- fix error message string for Ollama connection
- adjust streaming response string for better Python < 3.12 compatibility

## Testing
- `python -m py_compile backend.py`
- `pyenv shell 3.10.17 && python -m py_compile backend.py`


------
https://chatgpt.com/codex/tasks/task_e_686ff815c5c0832ebe84c553921dda17