### PR TITLE
Enable dynamic LM Studio model discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ This option is ideal if you don't want to worry about installing Python or depen
 6. If you want to use LM Studio or Ollama for local AI text improvement, set the host to
    `host.docker.internal` in the configuration page so the container can reach
    your local instance.
+   Use the **Update Models** button to fetch the list of available models from
+   `http://<lmstudio-host>:<port>/v1/models` automatically.
 
 ## Installing from the Terminal
 If you prefer not to use Docker, you can also run it directly with Python:

--- a/app.js
+++ b/app.js
@@ -3697,11 +3697,35 @@ class NotesApp {
     }
 
     updateLmStudioModelsList() {
+        const hostInput = document.getElementById('lmstudio-host');
+        const portInput = document.getElementById('lmstudio-port');
         const modelsInput = document.getElementById('lmstudio-models');
-        if (!modelsInput) return;
+        if (!hostInput || !portInput || !modelsInput) return;
 
-        this.config.lmstudioModels = modelsInput.value.trim();
-        this.updateModelOptions();
+        const host = hostInput.value.trim();
+        const port = portInput.value.trim();
+
+        backendAPI.listLmStudioModels(host, port)
+            .then(data => {
+                let ids = [];
+                if (data.data && Array.isArray(data.data)) {
+                    ids = data.data.map(m => m.id || m);
+                } else if (Array.isArray(data.models)) {
+                    ids = data.models.map(m => m.id || m);
+                }
+                if (ids.length > 0) {
+                    modelsInput.value = ids.join(',');
+                    this.config.lmstudioModels = modelsInput.value.trim();
+                    this.updateModelOptions();
+                    this.showNotification('LM Studio models updated');
+                } else {
+                    this.showNotification('No models found on LM Studio', 'warning');
+                }
+            })
+            .catch(err => {
+                console.error('Error fetching LM Studio models:', err);
+                this.showNotification('Failed to fetch LM Studio models', 'error');
+            });
     }
 
     updateOllamaModelsList() {

--- a/backend-api.js
+++ b/backend-api.js
@@ -586,6 +586,20 @@ class BackendAPI {
         }
     }
 
+    async listLmStudioModels(host, port) {
+        try {
+            const url = `${this.baseUrl}/api/lmstudio/models?host=${encodeURIComponent(host)}&port=${encodeURIComponent(port)}`;
+            const response = await fetch(url);
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            return await response.json();
+        } catch (error) {
+            console.error('Error listing LM Studio models:', error);
+            throw error;
+        }
+    }
+
     async deleteModel(name) {
         try {
             const response = await fetch(`${this.baseUrl}/api/delete-model`, {

--- a/backend.py
+++ b/backend.py
@@ -1766,6 +1766,24 @@ def list_models():
         return jsonify({"error": f"Error listing models: {str(e)}"}), 500
 
 
+@app.route('/api/lmstudio/models', methods=['GET'])
+def get_lmstudio_models():
+    """Query LM Studio for available models"""
+    host = request.args.get('host', LMSTUDIO_HOST)
+    port = request.args.get('port', LMSTUDIO_PORT)
+
+    try:
+        url = f"http://{host}:{port}/v1/models"
+        response = requests.get(url, timeout=5)
+        if response.status_code != 200:
+            return jsonify({"error": f"LM Studio error {response.status_code}"}), response.status_code
+        return jsonify(response.json())
+    except requests.RequestException as e:
+        return jsonify({"error": f"Error de conexión con LM Studio: {str(e)}"}), 500
+    except Exception as e:
+        return jsonify({"error": f"Error interno: {str(e)}"}), 500
+
+
 @app.route('/api/delete-model', methods=['POST'])
 def delete_model():
     """Delete a downloaded whisper.cpp model"""


### PR DESCRIPTION
## Summary
- add backend route to query LM Studio `/v1/models`
- expose `listLmStudioModels` in frontend API wrapper
- call dynamic query from the *Update Models* button
- document how to fetch LM Studio models

## Testing
- `python -m py_compile backend.py`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68709ccf34cc832e88dc2c0c4fa23f21