### PR TITLE
Enable note webhook integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Copy `env.example` to `.env` and add your API keys:
 cp env.example .env
 ```
 Edit the `.env` file and fill in the variables `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `DEEPSEEK_API_KEY` and `OPENROUTER_API_KEY` for the services you want to use. These keys enable cloud transcription and text enhancement.
+If you want to send each saved note to an external workflow (for example, an n8n or Dify instance), also set `WORKFLOW_WEBHOOK_URL` and optionally `WORKFLOW_WEBHOOK_TOKEN`.
 
 ## Usage Guide
 1. Press the microphone button to record audio and get real-time transcription.

--- a/env.example
+++ b/env.example
@@ -1,21 +1,27 @@
-# Archivo de ejemplo para las variables de entorno
-# Copia este archivo como .env y configura tus API keys
+# Example environment variables file
+# Copy this file as .env and set your API keys
 
-# Variables de entorno para las APIs
-OPENAI_API_KEY=tu_openai_api_key_aqui
-GOOGLE_API_KEY=tu_google_api_key_aqui
-DEEPSEEK_API_KEY=tu_deepseek_api_key_aqui
-OPENROUTER_API_KEY=tu_openrouter_api_key_aqui
+# API environment variables
+OPENAI_API_KEY=your_openai_api_key_here
+GOOGLE_API_KEY=your_google_api_key_here
+DEEPSEEK_API_KEY=your_deepseek_api_key_here
+OPENROUTER_API_KEY=your_openrouter_api_key_here
 
-# Configuración del backend
+# Backend configuration
 BACKEND_PORT=8000
 CORS_ORIGINS=https://localhost:5037,https://127.0.0.1:5037
 
-# Configuración de la aplicación
+# Application configuration
 DEBUG=False
-# Configuración de LM Studio (opcional)
+# LM Studio configuration (optional)
 LMSTUDIO_HOST=127.0.0.1
 LMSTUDIO_PORT=1234
-# Configuración de Ollama (opcional)
+# Ollama configuration (optional)
 OLLAMA_HOST=127.0.0.1
 OLLAMA_PORT=11434
+
+# Optional: integration with a workflow agent (for example, n8n)
+# Set the URL of a webhook where saved notes will be sent
+WORKFLOW_WEBHOOK_URL=
+# If your agent requires authentication, you can specify a token
+WORKFLOW_WEBHOOK_TOKEN=


### PR DESCRIPTION
## Summary
- allow WhisPad to send saved notes to a workflow webhook
- document new `WORKFLOW_WEBHOOK_URL` and token variables
- translate environment example comments to English

## Testing
- `python -m py_compile backend.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68709d843d98832eb4a076b7bcd4cd5a