### PR TITLE
Add per-user provider management

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ WhisPad is a transcription and note management tool designed so anyone can turn 
 - Download or upload local (.bin) whisper.cpp models directly from the interface.
 - Export all notes in a ZIP file with one click.
 - Mobile-friendly interface.
+- User login with per-user note folders and admin management tools.
 
 ## Disclaimer
 This application is currently in testing and is provided **as is**. I take no responsibility for any data loss that may occur when using it. Make sure you make frequent backups of your data.
@@ -41,7 +42,8 @@ If you are not comfortable with the terminal, the easiest method is to use **Doc
    docker compose up
    ```
 4. Docker will download the dependencies and show *"Starting services..."*. When everything is ready, open your browser at `https://localhost:5037`.
-5. To stop the application, press `Ctrl+C` in the terminal or use the *Stop* button in Docker Desktop.
+5. Sign in with **admin** / **whispad** the first time to access the app.
+6. To stop the application, press `Ctrl+C` in the terminal or use the *Stop* button in Docker Desktop.
 
 ## Installing with Docker Desktop
 This option is ideal if you don't want to worry about installing Python or dependencies manually.
@@ -58,8 +60,9 @@ This option is ideal if you don't want to worry about installing Python or depen
    docker compose up
    ```
 4. Go to `https://localhost:5037` and start using WhisPad.
-5. To stop it, press `Ctrl+C` in the terminal or run `docker compose down`.
-6. If you want to use LM Studio or Ollama for local AI text improvement, set the host to
+5. Log in with **admin** / **whispad** on first use.
+6. To stop it, press `Ctrl+C` in the terminal or run `docker compose down`.
+7. If you want to use LM Studio or Ollama for local AI text improvement, set the host to
    `host.docker.internal` in the configuration page so the container can reach
    your local instance.
    Use the **Update Models** button to fetch the list of available models from
@@ -88,6 +91,7 @@ If you prefer not to use Docker, you can also run it directly with Python:
    python backend.py
    ```
 6. Open `index.html` in your browser or serve the folder with `python -m http.server 5037` and visit `https://localhost:5037`.
+7. Log in with **admin** / **whispad** the first time you access the app.
 
 ## API Key Configuration
 Copy `env.example` to `.env` and add your API keys:
@@ -96,6 +100,7 @@ cp env.example .env
 ```
 Edit the `.env` file and fill in the variables `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `DEEPSEEK_API_KEY` and `OPENROUTER_API_KEY` for the services you want to use. These keys enable cloud transcription and text enhancement.
 If you want to send each saved note to an external workflow (for example, an n8n or Dify instance), also set `WORKFLOW_WEBHOOK_URL` and optionally `WORKFLOW_WEBHOOK_TOKEN`.
+The webhook payload now includes the username so your workflow can fetch the note from the correct folder.
 
 ## Usage Guide
 1. Press the microphone button to record audio and get real-time transcription.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ cp env.example .env
 ```
 Edit the `.env` file and fill in the variables `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `DEEPSEEK_API_KEY` and `OPENROUTER_API_KEY` for the services you want to use. These keys enable cloud transcription and text enhancement.
 If you want to send each saved note to an external workflow (for example, an n8n or Dify instance), also set `WORKFLOW_WEBHOOK_URL` and optionally `WORKFLOW_WEBHOOK_TOKEN`.
+You can override the username included in the webhook by defining `WORKFLOW_WEBHOOK_USER`.
 The webhook payload now includes the username so your workflow can fetch the note from the correct folder.
 
 ## Usage Guide

--- a/app.js
+++ b/app.js
@@ -387,14 +387,13 @@ class NotesApp {
             this.showStylesConfigModal();
         });
 
-        document.getElementById('user-btn').addEventListener('click', async () => {
-            document.getElementById('user-modal').classList.add('active');
+        async function refreshUserList() {
             const listResp = await authFetch('/api/list-users');
             if (listResp.ok) {
                 const data = await listResp.json();
                 const list = document.getElementById('users-list');
                 list.innerHTML = '';
-                data.users.forEach(u => {
+                data.users.filter(u => u.username !== 'admin').forEach(u => {
                     const li = document.createElement('li');
                     li.className = 'user-item';
                     const title = document.createElement('strong');
@@ -461,6 +460,11 @@ class NotesApp {
                     list.appendChild(li);
                 });
             }
+        }
+
+        document.getElementById('user-btn').addEventListener('click', async () => {
+            document.getElementById('user-modal').classList.add('active');
+            await refreshUserList();
         });
         document.getElementById('close-user-modal').addEventListener('click', () => {
             document.getElementById('user-modal').classList.remove('active');
@@ -510,6 +514,7 @@ class NotesApp {
                 document.getElementById('create-username').value = '';
                 document.getElementById('create-password').value = '';
                 document.querySelectorAll('#create-tab input[type="checkbox"]').forEach(cb => cb.checked = false);
+                await refreshUserList();
             } else {
                 alert('Error creating user');
             }
@@ -4000,7 +4005,8 @@ function initApp() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    const loginModal = document.getElementById('login-modal');
+    const loginScreen = document.getElementById('login-screen');
+    const appContent = document.getElementById('app-content');
     const loginBtn = document.getElementById('login-submit');
     const currentUserBtn = document.getElementById('current-user-btn');
     const logoutBtn = document.getElementById('logout-btn');
@@ -4025,7 +4031,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 currentUserBtn.textContent = username;
                 currentUserBtn.classList.remove('hidden');
                 logoutBtn.classList.remove('hidden');
-                loginModal.classList.remove('active');
+                loginScreen.classList.add('hidden');
+                appContent.classList.remove('hidden');
                 initApp();
             } else {
                 alert('Login failed');
@@ -4044,7 +4051,8 @@ document.addEventListener('DOMContentLoaded', () => {
         currentUserBtn.classList.add('hidden');
         logoutBtn.classList.add('hidden');
         document.getElementById('user-btn').classList.add('hidden');
-        loginModal.classList.add('active');
+        loginScreen.classList.remove('hidden');
+        appContent.classList.add('hidden');
     });
 });
 

--- a/app.js
+++ b/app.js
@@ -1,3 +1,20 @@
+// Authentication token and current user
+let authToken = '';
+let currentUser = '';
+
+const TRANSCRIPTION_PROVIDERS = ['openai', 'local', 'sensevoice'];
+const POSTPROCESS_PROVIDERS = ['openai', 'google', 'openrouter', 'lmstudio', 'ollama'];
+let allowedTranscriptionProviders = [];
+let allowedPostprocessProviders = [];
+
+function authFetch(url, options = {}) {
+    options.headers = options.headers || {};
+    if (authToken) {
+        options.headers['Authorization'] = authToken;
+    }
+    return fetch(url, options);
+}
+
 // Example data and configuration
 const ejemplosTranscripcion = [
     "This is a dictated note about the web development project we are working on in the office.",
@@ -146,7 +163,7 @@ class NotesApp {
     
     async migrateExistingNotes() {
         try {
-            const response = await fetch('/api/cleanup-notes', {
+            const response = await authFetch('/api/cleanup-notes', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
@@ -369,6 +386,136 @@ class NotesApp {
         document.getElementById('styles-config-btn').addEventListener('click', () => {
             this.showStylesConfigModal();
         });
+
+        document.getElementById('user-btn').addEventListener('click', async () => {
+            document.getElementById('user-modal').classList.add('active');
+            const listResp = await authFetch('/api/list-users');
+            if (listResp.ok) {
+                const data = await listResp.json();
+                const list = document.getElementById('users-list');
+                list.innerHTML = '';
+                data.users.forEach(u => {
+                    const li = document.createElement('li');
+                    li.className = 'user-item';
+                    const title = document.createElement('strong');
+                    title.textContent = u.username;
+                    li.appendChild(title);
+
+                    const tGroup = document.createElement('div');
+                    tGroup.className = 'provider-group';
+                    tGroup.append('Transcription: ');
+                    TRANSCRIPTION_PROVIDERS.forEach(p => {
+                        const label = document.createElement('label');
+                        label.style.marginRight = '6px';
+                        const cb = document.createElement('input');
+                        cb.type = 'checkbox';
+                        cb.value = p;
+                        cb.className = 'edit-transcription';
+                        if ((u.transcription_providers || []).includes(p)) cb.checked = true;
+                        label.appendChild(cb);
+                        label.append(' ' + p);
+                        tGroup.appendChild(label);
+                    });
+                    li.appendChild(tGroup);
+
+                    const ppGroup = document.createElement('div');
+                    ppGroup.className = 'provider-group';
+                    ppGroup.append('Post-process: ');
+                    POSTPROCESS_PROVIDERS.forEach(p => {
+                        const label = document.createElement('label');
+                        label.style.marginRight = '6px';
+                        const cb = document.createElement('input');
+                        cb.type = 'checkbox';
+                        cb.value = p;
+                        cb.className = 'edit-postprocess';
+                        if ((u.postprocess_providers || []).includes(p)) cb.checked = true;
+                        label.appendChild(cb);
+                        label.append(' ' + p);
+                        ppGroup.appendChild(label);
+                    });
+                    li.appendChild(ppGroup);
+
+                    const saveBtn = document.createElement('button');
+                    saveBtn.className = 'btn btn--primary btn--sm';
+                    saveBtn.textContent = 'Save';
+                    saveBtn.addEventListener('click', async () => {
+                        const tProviders = Array.from(li.querySelectorAll('.edit-transcription:checked')).map(c => c.value);
+                        const ppProviders = Array.from(li.querySelectorAll('.edit-postprocess:checked')).map(c => c.value);
+                        const resp2 = await authFetch('/api/update-user-providers', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({
+                                username: u.username,
+                                transcription_providers: tProviders,
+                                postprocess_providers: ppProviders
+                            })
+                        });
+                        if (resp2.ok) {
+                            alert('Updated ' + u.username);
+                        } else {
+                            alert('Error updating user');
+                        }
+                    });
+                    li.appendChild(saveBtn);
+
+                    list.appendChild(li);
+                });
+            }
+        });
+        document.getElementById('close-user-modal').addEventListener('click', () => {
+            document.getElementById('user-modal').classList.remove('active');
+        });
+
+        document.querySelectorAll('#user-modal .tab-buttons button').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const tab = btn.getAttribute('data-tab');
+                document.querySelectorAll('#user-modal .tab-content').forEach(c => c.style.display = 'none');
+                document.getElementById(tab).style.display = 'block';
+            });
+        });
+
+        document.getElementById('change-password-btn').addEventListener('click', async () => {
+            const newPass = document.getElementById('new-password').value;
+            if (!newPass) return;
+            const resp = await authFetch('/api/change-password', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ password: newPass })
+            });
+            if (resp.ok) {
+                alert('Password updated');
+            } else {
+                alert('Error updating password');
+            }
+        });
+
+        document.getElementById('create-user-btn').addEventListener('click', async () => {
+            const u = document.getElementById('create-username').value.trim();
+            const p = document.getElementById('create-password').value;
+            if (!u || !p) return;
+            const tProviders = Array.from(document.querySelectorAll('.create-transcription-provider:checked')).map(cb => cb.value);
+            const ppProviders = Array.from(document.querySelectorAll('.create-postprocess-provider:checked')).map(cb => cb.value);
+            const resp = await authFetch('/api/create-user', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    username: u,
+                    password: p,
+                    transcription_providers: tProviders,
+                    postprocess_providers: ppProviders
+                })
+            });
+            if (resp.ok) {
+                alert('User created');
+                document.getElementById('create-username').value = '';
+                document.getElementById('create-password').value = '';
+                document.querySelectorAll('#create-tab input[type="checkbox"]').forEach(cb => cb.checked = false);
+            } else {
+                alert('Error creating user');
+            }
+        });
+
+        document.getElementById('user-btn').classList.remove('hidden');
         
         document.getElementById('cancel-config').addEventListener('click', () => {
             this.hideConfigModal();
@@ -510,7 +657,7 @@ class NotesApp {
     // Gestión de notas
     async loadNotes() {
         try {
-            const response = await fetch('/api/list-saved-notes');
+            const response = await authFetch('/api/list-saved-notes');
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}`);
             }
@@ -539,7 +686,7 @@ class NotesApp {
             ? `?id=${note.id}`
             : `?filename=${encodeURIComponent(note.filename)}`;
         try {
-            const response = await fetch(`/api/get-note${params}`);
+            const response = await authFetch(`/api/get-note${params}`);
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}`);
             }
@@ -637,8 +784,33 @@ class NotesApp {
     }
 
     showConfigModal() {
-        document.getElementById('transcription-provider').value = this.config.transcriptionProvider;
-        document.getElementById('postprocess-provider').value = this.config.postprocessProvider;
+        const tpSelect = document.getElementById('transcription-provider');
+        const ppSelect = document.getElementById('postprocess-provider');
+
+        tpSelect.querySelectorAll('option').forEach(opt => {
+            if (!opt.value) return;
+            if (allowedTranscriptionProviders.length && !allowedTranscriptionProviders.includes(opt.value)) {
+                opt.disabled = true;
+                opt.style.display = 'none';
+            } else {
+                opt.disabled = false;
+                opt.style.display = '';
+            }
+        });
+
+        ppSelect.querySelectorAll('option').forEach(opt => {
+            if (!opt.value) return;
+            if (allowedPostprocessProviders.length && !allowedPostprocessProviders.includes(opt.value)) {
+                opt.disabled = true;
+                opt.style.display = 'none';
+            } else {
+                opt.disabled = false;
+                opt.style.display = '';
+            }
+        });
+
+        tpSelect.value = this.config.transcriptionProvider;
+        ppSelect.value = this.config.postprocessProvider;
         document.getElementById('transcription-model').value = this.config.transcriptionModel || '';
         document.getElementById('postprocess-model').value = this.config.postprocessModel || '';
         document.getElementById('transcription-language').value = this.config.transcriptionLanguage || 'auto';
@@ -1013,7 +1185,7 @@ class NotesApp {
         if (!this.currentNote) return;
         
         try {
-            const response = await fetch('/api/save-note', {
+            const response = await authFetch('/api/save-note', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
@@ -1064,7 +1236,7 @@ class NotesApp {
     
     async deleteNoteFromServer(noteId) {
         try {
-            const response = await fetch('/api/delete-note', {
+            const response = await authFetch('/api/delete-note', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
@@ -1117,7 +1289,7 @@ class NotesApp {
 
     async downloadAllNotes() {
         try {
-            const response = await fetch('/api/download-all-notes');
+            const response = await authFetch('/api/download-all-notes');
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}`);
             }
@@ -1281,7 +1453,7 @@ class NotesApp {
     async uploadNoteFile(file) {
         const formData = new FormData();
         formData.append('note', file, file.name);
-        const response = await fetch('/api/upload-note', { method: 'POST', body: formData });
+        const response = await authFetch('/api/upload-note', { method: 'POST', body: formData });
         if (!response.ok) {
             throw new Error('Upload failed');
         }
@@ -1542,6 +1714,7 @@ class NotesApp {
                 });
                 
                 xhr.open('POST', '/api/upload-model');
+                if (authToken) xhr.setRequestHeader('Authorization', authToken);
                 xhr.send(formData);
             });
             
@@ -1560,8 +1733,8 @@ class NotesApp {
         const timeoutId = setTimeout(() => controller.abort(), 30 * 60 * 1000); // 30 minutes timeout
         
         try {
-            const response = await fetch('/api/upload-model', { 
-                method: 'POST', 
+            const response = await authFetch('/api/upload-model', {
+                method: 'POST',
                 body: formData,
                 signal: controller.signal
             });
@@ -3822,8 +3995,57 @@ class NotesApp {
 }
 
 // Inicializar la aplicación cuando se carga la página
-document.addEventListener('DOMContentLoaded', () => {
+function initApp() {
     window.notesApp = new NotesApp();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const loginModal = document.getElementById('login-modal');
+    const loginBtn = document.getElementById('login-submit');
+    const currentUserBtn = document.getElementById('current-user-btn');
+    const logoutBtn = document.getElementById('logout-btn');
+    loginBtn.addEventListener('click', async () => {
+        const username = document.getElementById('login-username').value.trim();
+        const password = document.getElementById('login-password').value;
+        try {
+            const resp = await fetch('/api/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, password })
+            });
+            if (resp.ok) {
+                const data = await resp.json();
+                authToken = data.token;
+                currentUser = username;
+                allowedTranscriptionProviders = data.transcription_providers || [];
+                allowedPostprocessProviders = data.postprocess_providers || [];
+                if (!data.is_admin) {
+                    document.querySelectorAll('.admin-only').forEach(el => el.style.display = 'none');
+                }
+                currentUserBtn.textContent = username;
+                currentUserBtn.classList.remove('hidden');
+                logoutBtn.classList.remove('hidden');
+                loginModal.classList.remove('active');
+                initApp();
+            } else {
+                alert('Login failed');
+            }
+        } catch (e) {
+            alert('Login error');
+        }
+    });
+
+    logoutBtn.addEventListener('click', async () => {
+        await authFetch('/api/logout', { method: 'POST' });
+        authToken = '';
+        currentUser = '';
+        allowedTranscriptionProviders = [];
+        allowedPostprocessProviders = [];
+        currentUserBtn.classList.add('hidden');
+        logoutBtn.classList.add('hidden');
+        document.getElementById('user-btn').classList.add('hidden');
+        loginModal.classList.add('active');
+    });
 });
 
 // Actualizar botones de formato cuando cambia la selección

--- a/backend.py
+++ b/backend.py
@@ -1302,7 +1302,13 @@ def save_note():
             try:
                 requests.post(
                     WORKFLOW_WEBHOOK_URL,
-                    json={"id": note_id, "title": title, "content": content, "tags": tags},
+                    json={
+                        "id": note_id,
+                        "title": title,
+                        "content": content,
+                        "tags": tags,
+                        "user": username,
+                    },
                     headers=headers,
                     timeout=5,
                 )

--- a/backend.py
+++ b/backend.py
@@ -68,7 +68,29 @@ def save_users(users):
     with open(USERS_FILE, 'w', encoding='utf-8') as f:
         json.dump(users, f, indent=2)
 
+
+def migrate_notes_to_admin_folder():
+    """Move existing notes in saved_notes/ to saved_notes/admin"""
+    root_dir = os.path.join(os.getcwd(), 'saved_notes')
+    if not os.path.isdir(root_dir):
+        return
+
+    admin_dir = os.path.join(root_dir, 'admin')
+    moved = 0
+
+    for fname in os.listdir(root_dir):
+        path = os.path.join(root_dir, fname)
+        if os.path.isfile(path) and (fname.endswith('.md') or fname.endswith('.meta')):
+            os.makedirs(admin_dir, exist_ok=True)
+            shutil.move(path, os.path.join(admin_dir, fname))
+            moved += 1
+
+    if moved:
+        print(f"Migrated {moved} notes to {admin_dir}")
+
+
 USERS = load_users()
+migrate_notes_to_admin_folder()
 
 def get_current_username():
     token = request.headers.get('Authorization')

--- a/backend.py
+++ b/backend.py
@@ -40,6 +40,7 @@ OLLAMA_PORT = os.getenv('OLLAMA_PORT', '11434')
 # Opcional: enviar las notas guardadas a un flujo de trabajo externo
 WORKFLOW_WEBHOOK_URL = os.getenv('WORKFLOW_WEBHOOK_URL')
 WORKFLOW_WEBHOOK_TOKEN = os.getenv('WORKFLOW_WEBHOOK_TOKEN')
+WORKFLOW_WEBHOOK_USER = os.getenv('WORKFLOW_WEBHOOK_USER')
 
 # ---------- Simple user management ---------
 USERS_FILE = 'users.json'
@@ -1299,6 +1300,7 @@ def save_note():
             headers = {"Content-Type": "application/json"}
             if WORKFLOW_WEBHOOK_TOKEN:
                 headers["Authorization"] = f"Bearer {WORKFLOW_WEBHOOK_TOKEN}"
+            webhook_user = WORKFLOW_WEBHOOK_USER or username
             try:
                 requests.post(
                     WORKFLOW_WEBHOOK_URL,
@@ -1307,7 +1309,7 @@ def save_note():
                         "title": title,
                         "content": content,
                         "tags": tags,
-                        "user": username,
+                        "user": webhook_user,
                     },
                     headers=headers,
                     timeout=5,

--- a/backend.py
+++ b/backend.py
@@ -41,6 +41,41 @@ OLLAMA_PORT = os.getenv('OLLAMA_PORT', '11434')
 WORKFLOW_WEBHOOK_URL = os.getenv('WORKFLOW_WEBHOOK_URL')
 WORKFLOW_WEBHOOK_TOKEN = os.getenv('WORKFLOW_WEBHOOK_TOKEN')
 
+# ---------- Simple user management ---------
+USERS_FILE = 'users.json'
+SESSIONS = {}
+
+def load_users():
+    if not os.path.exists(USERS_FILE):
+        default_users = {
+            "admin": {
+                "password": "whispad",
+                "is_admin": True,
+                "transcription_providers": ["openai", "local", "sensevoice"],
+                "postprocess_providers": ["openai"]
+            }
+        }
+        with open(USERS_FILE, 'w', encoding='utf-8') as f:
+            json.dump(default_users, f, indent=2)
+        return default_users
+    try:
+        with open(USERS_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+def save_users(users):
+    with open(USERS_FILE, 'w', encoding='utf-8') as f:
+        json.dump(users, f, indent=2)
+
+USERS = load_users()
+
+def get_current_username():
+    token = request.headers.get('Authorization')
+    if not token:
+        return None
+    return SESSIONS.get(token)
+
 # Inicializar el wrapper de whisper.cpp local
 try:
     whisper_wrapper = WhisperCppWrapper()
@@ -68,10 +103,109 @@ def health_check():
     """Endpoint para verificar que el backend está funcionando"""
     return jsonify({"status": "ok", "message": "Backend funcionando correctamente"})
 
+# --- Authentication and user management endpoints ---
+
+@app.route('/api/login', methods=['POST'])
+def login_user():
+    data = request.get_json() or {}
+    username = data.get('username')
+    password = data.get('password')
+    user = USERS.get(username)
+    if user and user.get('password') == password:
+        token = base64.urlsafe_b64encode(os.urandom(24)).decode('utf-8')
+        SESSIONS[token] = username
+        return jsonify({
+            "success": True,
+            "token": token,
+            "is_admin": user.get('is_admin', False),
+            "transcription_providers": user.get('transcription_providers', []),
+            "postprocess_providers": user.get('postprocess_providers', [])
+        })
+    return jsonify({"success": False}), 401
+
+
+@app.route('/api/logout', methods=['POST'])
+def logout_user():
+    token = request.headers.get('Authorization')
+    if token in SESSIONS:
+        SESSIONS.pop(token, None)
+    return jsonify({"success": True})
+
+
+@app.route('/api/change-password', methods=['POST'])
+def change_password():
+    username = get_current_username()
+    if not username:
+        return jsonify({"error": "Unauthorized"}), 401
+    data = request.get_json() or {}
+    new_password = data.get('password')
+    if not new_password:
+        return jsonify({"error": "Password required"}), 400
+    USERS[username]['password'] = new_password
+    save_users(USERS)
+    return jsonify({"success": True})
+
+
+@app.route('/api/create-user', methods=['POST'])
+def create_user():
+    admin = get_current_username()
+    if not admin or not USERS.get(admin, {}).get('is_admin'):
+        return jsonify({"error": "Unauthorized"}), 401
+    data = request.get_json() or {}
+    username = data.get('username')
+    password = data.get('password')
+    if not username or not password:
+        return jsonify({"error": "Username and password required"}), 400
+    if username in USERS:
+        return jsonify({"error": "User exists"}), 400
+    USERS[username] = {
+        "password": password,
+        "is_admin": False,
+        "transcription_providers": data.get('transcription_providers', []),
+        "postprocess_providers": data.get('postprocess_providers', [])
+    }
+    save_users(USERS)
+    return jsonify({"success": True})
+
+
+@app.route('/api/list-users', methods=['GET'])
+def list_users():
+    admin = get_current_username()
+    if not admin or not USERS.get(admin, {}).get('is_admin'):
+        return jsonify({"error": "Unauthorized"}), 401
+    users = []
+    for name, info in USERS.items():
+        users.append({
+            "username": name,
+            "is_admin": info.get('is_admin', False),
+            "transcription_providers": info.get('transcription_providers', []),
+            "postprocess_providers": info.get('postprocess_providers', [])
+        })
+    return jsonify({"users": users})
+
+
+@app.route('/api/update-user-providers', methods=['POST'])
+def update_user_providers():
+    admin = get_current_username()
+    if not admin or not USERS.get(admin, {}).get('is_admin'):
+        return jsonify({"error": "Unauthorized"}), 401
+    data = request.get_json() or {}
+    username = data.get('username')
+    if username not in USERS:
+        return jsonify({"error": "User not found"}), 404
+    USERS[username]['transcription_providers'] = data.get('transcription_providers', USERS[username].get('transcription_providers', []))
+    USERS[username]['postprocess_providers'] = data.get('postprocess_providers', USERS[username].get('postprocess_providers', []))
+    save_users(USERS)
+    return jsonify({"success": True})
+
 @app.route('/api/transcribe', methods=['POST'])
 def transcribe_audio():
     """Endpoint para transcribir audio usando OpenAI o whisper.cpp local"""
     try:
+        username = get_current_username()
+        if not username:
+            return jsonify({"error": "Unauthorized"}), 401
+
         # Obtener el archivo de audio del request
         if 'audio' not in request.files:
             return jsonify({"error": "No se encontró archivo de audio"}), 400
@@ -83,6 +217,10 @@ def transcribe_audio():
         # Obtener parámetros del request
         language = request.form.get('language', None)  # None = detección automática
         provider = request.form.get('provider', 'openai')  # openai o local
+
+        allowed = USERS.get(username, {}).get('transcription_providers', [])
+        if allowed and provider not in allowed:
+            return jsonify({"error": "Transcription provider not allowed"}), 403
         model_name = request.form.get('model')
         
         # Verificar disponibilidad del proveedor
@@ -196,6 +334,10 @@ def transcribe_audio():
 def improve_text():
     """Endpoint para mejorar texto usando OpenAI o Google AI"""
     try:
+        username = get_current_username()
+        if not username:
+            return jsonify({"error": "Unauthorized"}), 401
+
         data = request.get_json()
         if not data or 'text' not in data or 'improvement_type' not in data:
             return jsonify({"error": "Faltan parámetros requeridos"}), 400
@@ -203,6 +345,10 @@ def improve_text():
         text = data['text']
         improvement_type = data['improvement_type']
         provider = data.get('provider', 'openai')  # openai o google
+
+        allowed = USERS.get(username, {}).get('postprocess_providers', [])
+        if allowed and provider not in allowed:
+            return jsonify({"error": "Post-process provider not allowed"}), 403
         stream = data.get('stream', False)  # Nuevo parámetro para streaming
         custom_prompt = data.get('custom_prompt')  # Nuevo parámetro para prompts personalizados
         
@@ -874,6 +1020,14 @@ def transcribe_audio_gpt4o():
     try:
         print(f"[DEBUG] Iniciando transcripción GPT-4o...")
         
+        username = get_current_username()
+        if not username:
+            return jsonify({"error": "Unauthorized"}), 401
+
+        allowed = USERS.get(username, {}).get('transcription_providers', [])
+        if allowed and 'openai' not in allowed:
+            return jsonify({"error": "Transcription provider not allowed"}), 403
+
         if not OPENAI_API_KEY:
             print(f"[ERROR] API key de OpenAI no configurada")
             return jsonify({"error": "API key de OpenAI no configurada"}), 500
@@ -1006,6 +1160,9 @@ def stream_transcription_response(response):
 def save_note():
     """Endpoint para guardar una nota como archivo .md en el directorio saved_notes"""
     try:
+        username = get_current_username()
+        if not username:
+            return jsonify({"error": "Unauthorized"}), 401
         data = request.get_json()
         
         if not data:
@@ -1029,7 +1186,7 @@ def save_note():
             return jsonify({"error": "La nota debe tener al menos un título o contenido"}), 400
         
         # Crear directorio saved_notes si no existe
-        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes')
+        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes', username)
         os.makedirs(saved_notes_dir, exist_ok=True)
         
         # Generar nombre de archivo seguro basado en el título
@@ -1233,7 +1390,10 @@ def check_apis():
 def list_saved_notes():
     """Endpoint para listar las notas guardadas en el servidor"""
     try:
-        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes')
+        username = get_current_username()
+        if not username:
+            return jsonify({"error": "Unauthorized"}), 401
+        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes', username)
         
         if not os.path.exists(saved_notes_dir):
             return jsonify({"notes": [], "message": "Directorio saved_notes no existe"})
@@ -1284,7 +1444,10 @@ def list_saved_notes():
 def cleanup_notes():
     """Endpoint para migrar notas existentes sin ID a la nueva estructura"""
     try:
-        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes')
+        username = get_current_username()
+        if not username:
+            return jsonify({"error": "Unauthorized"}), 401
+        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes', username)
         if not os.path.exists(saved_notes_dir):
             return jsonify({"message": "No hay directorio de notas guardadas"}), 200
         
@@ -1329,6 +1492,9 @@ def cleanup_notes():
 def delete_note():
     """Endpoint para eliminar una nota del servidor"""
     try:
+        username = get_current_username()
+        if not username:
+            return jsonify({"error": "Unauthorized"}), 401
         data = request.get_json()
         
         if not data:
@@ -1340,7 +1506,7 @@ def delete_note():
             return jsonify({"error": "ID de nota requerido"}), 400
         
         # Buscar el archivo correspondiente al note_id
-        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes')
+        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes', username)
         
         if not os.path.exists(saved_notes_dir):
             return jsonify({"error": "Directorio de notas no existe"}), 404
@@ -1384,7 +1550,10 @@ def delete_note():
 def list_notes():
     """Endpoint para listar notas (guardadas y no guardadas) en el servidor"""
     try:
-        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes')
+        username = get_current_username()
+        if not username:
+            return jsonify({"error": "Unauthorized"}), 401
+        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes', username)
         
         # Obtener todas las notas guardadas
         saved_notes = []
@@ -1431,7 +1600,10 @@ def list_notes():
 def download_all_notes():
     """Descarga todas las notas guardadas como un archivo ZIP"""
     try:
-        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes')
+        username = get_current_username()
+        if not username:
+            return jsonify({"error": "Unauthorized"}), 401
+        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes', username)
         if not os.path.exists(saved_notes_dir):
             return jsonify({"error": "No hay notas guardadas"}), 404
 
@@ -1449,6 +1621,9 @@ def download_all_notes():
 def upload_note():
     """Sube una nota markdown al directorio saved_notes"""
     try:
+        username = get_current_username()
+        if not username:
+            return jsonify({"error": "Unauthorized"}), 401
         if 'note' not in request.files:
             return jsonify({"error": "No se recibió archivo"}), 400
 
@@ -1460,7 +1635,7 @@ def upload_note():
         if ext not in ['.md', '.meta']:
             return jsonify({"error": "Tipo de archivo no válido"}), 400
 
-        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes')
+        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes', username)
         os.makedirs(saved_notes_dir, exist_ok=True)
         filepath = os.path.join(saved_notes_dir, note_file.filename)
         overwritten = os.path.exists(filepath)
@@ -1829,10 +2004,13 @@ def delete_model():
 def get_note():
     """Devuelve el contenido de una nota especificada por ID o nombre de archivo"""
     try:
+        username = get_current_username()
+        if not username:
+            return jsonify({"error": "Unauthorized"}), 401
         note_id = request.args.get('id')
         filename = request.args.get('filename')
 
-        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes')
+        saved_notes_dir = os.path.join(os.getcwd(), 'saved_notes', username)
         if not os.path.exists(saved_notes_dir):
             return jsonify({"error": "Directorio de notas no existe"}), 404
 

--- a/env.example
+++ b/env.example
@@ -25,3 +25,5 @@ OLLAMA_PORT=11434
 WORKFLOW_WEBHOOK_URL=
 # If your agent requires authentication, you can specify a token
 WORKFLOW_WEBHOOK_TOKEN=
+# Optional: override the username included in the webhook payload
+WORKFLOW_WEBHOOK_USER=

--- a/index.html
+++ b/index.html
@@ -9,9 +9,9 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
 <body>
-    <!-- Login modal -->
-    <div class="modal active" id="login-modal">
-        <div class="modal-content">
+    <!-- Login screen -->
+    <div class="login-screen" id="login-screen">
+        <div class="login-box">
             <img src="logos/logo.png" alt="WhisPad Logo" class="login-logo">
             <h3>Login</h3>
             <div class="modal-body">
@@ -64,6 +64,7 @@
             </div>
         </div>
     </div>
+    <div id="app-content" class="hidden">
     <!-- App Header -->
     <header class="app-header">
         <div class="app-brand">
@@ -589,6 +590,7 @@
     <button id="mobile-record-fab" class="mobile-fab" aria-label="Record">
         <i class="fas fa-microphone"></i>
     </button>
+    </div> <!-- end app-content -->
     <script src="backend-api.js"></script>
     <script src="app.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,61 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
 <body>
+    <!-- Login modal -->
+    <div class="modal active" id="login-modal">
+        <div class="modal-content">
+            <img src="logos/logo.png" alt="WhisPad Logo" class="login-logo">
+            <h3>Login</h3>
+            <div class="modal-body">
+                <input type="text" class="form-control" id="login-username" placeholder="Username">
+                <input type="password" class="form-control" id="login-password" placeholder="Password" style="margin-top:10px;">
+            </div>
+            <div class="modal-actions">
+                <button class="btn btn--primary" id="login-submit">Login</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- User management modal -->
+    <div class="modal" id="user-modal">
+        <div class="modal-content modal-content--wide">
+            <h3>User Management</h3>
+            <div class="modal-body">
+                <div class="tab-buttons">
+                    <button class="btn btn--outline btn--sm" data-tab="password-tab">Change Password</button>
+                    <button class="btn btn--outline btn--sm admin-only" data-tab="create-tab">Create User</button>
+                    <button class="btn btn--outline btn--sm admin-only" data-tab="list-tab">Existing Users</button>
+                </div>
+                <div class="tab-content" id="password-tab">
+                    <input type="password" class="form-control" id="new-password" placeholder="New password">
+                    <button class="btn btn--primary btn--sm" id="change-password-btn" style="margin-top:10px;">Save</button>
+                </div>
+                <div class="tab-content admin-only" id="create-tab" style="display:none;">
+                    <input type="text" class="form-control" id="create-username" placeholder="Username">
+                    <input type="password" class="form-control" id="create-password" placeholder="Password" style="margin-top:10px;">
+                    <div class="provider-select">
+                        <p>Transcription Providers</p>
+                        <label><input type="checkbox" class="create-transcription-provider" value="openai"> OpenAI</label>
+                        <label><input type="checkbox" class="create-transcription-provider" value="local"> Local</label>
+                        <label><input type="checkbox" class="create-transcription-provider" value="sensevoice"> SenseVoice</label>
+                        <p style="margin-top:10px;">Post-process Providers</p>
+                        <label><input type="checkbox" class="create-postprocess-provider" value="openai"> OpenAI</label>
+                        <label><input type="checkbox" class="create-postprocess-provider" value="google"> Google</label>
+                        <label><input type="checkbox" class="create-postprocess-provider" value="openrouter"> OpenRouter</label>
+                        <label><input type="checkbox" class="create-postprocess-provider" value="lmstudio"> LM Studio</label>
+                        <label><input type="checkbox" class="create-postprocess-provider" value="ollama"> Ollama</label>
+                    </div>
+                    <button class="btn btn--primary btn--sm" id="create-user-btn" style="margin-top:10px;">Create</button>
+                </div>
+                <div class="tab-content admin-only" id="list-tab" style="display:none;">
+                    <ul id="users-list"></ul>
+                </div>
+            </div>
+            <div class="modal-actions">
+                <button class="btn btn--outline" id="close-user-modal">Close</button>
+            </div>
+        </div>
+    </div>
     <!-- App Header -->
     <header class="app-header">
         <div class="app-brand">
@@ -25,6 +80,11 @@
             <button class="btn btn--outline btn--sm" id="upload-models-btn" title="Manage whisper.cpp models">
                 <i class="fas fa-download"></i>&nbsp;Models
             </button>
+            <button class="btn btn--outline btn--sm hidden" id="user-btn" title="User management">
+                <i class="fas fa-users"></i>&nbsp;Users
+            </button>
+            <button class="btn btn--outline btn--sm hidden" id="current-user-btn"></button>
+            <button class="btn btn--error btn--sm hidden" id="logout-btn">Logout</button>
             <button class="hamburger-menu" id="hamburger-menu" aria-label="Show/Hide notes menu">
                 <span></span><span></span><span></span>
             </button>

--- a/style.css
+++ b/style.css
@@ -525,6 +525,20 @@ pre code {
   background: var(--color-secondary);
 }
 
+.btn--error {
+  background: var(--color-error);
+  color: var(--color-btn-primary-text);
+}
+
+.btn--error:hover {
+  background: rgba(var(--color-error-rgb), 0.9);
+}
+
+.btn--error:active {
+  background: var(--color-error);
+  opacity: 0.9;
+}
+
 .btn--sm {
   padding: var(--space-4) var(--space-12);
   font-size: var(--font-size-sm);
@@ -1243,6 +1257,18 @@ select.form-control {
     max-width: 700px;
     box-shadow: var(--shadow-lg);
     position: relative;
+}
+
+#login-modal .modal-content {
+    text-align: center;
+}
+
+.login-logo {
+    width: 64px;
+    height: 64px;
+    object-fit: contain;
+    display: block;
+    margin: 0 auto var(--space-16) auto;
 }
 
 .modal-content--wide {
@@ -2358,4 +2384,32 @@ select.form-control {
 .model-name {
     font-size: var(--font-size-sm);
     color: var(--color-text);
+}
+
+/* User modal */
+.tab-buttons {
+    display: flex;
+    gap: var(--space-8);
+    margin-bottom: var(--space-16);
+}
+.tab-content {
+    margin-top: var(--space-8);
+}
+
+.provider-select label {
+    display: inline-block;
+    margin-right: var(--space-8);
+}
+
+.provider-group {
+    margin: var(--space-8) 0;
+}
+
+.user-item {
+    border-bottom: 1px solid var(--color-border);
+    padding: var(--space-8) 0;
+}
+
+.user-item:last-child {
+    border-bottom: none;
 }

--- a/style.css
+++ b/style.css
@@ -1259,8 +1259,30 @@ select.form-control {
     position: relative;
 }
 
-#login-modal .modal-content {
+
+/* Login screen */
+.login-screen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: var(--color-surface);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.login-box {
     text-align: center;
+    background-color: var(--color-surface);
+    padding: var(--space-24);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    width: 80%;
+    max-width: 400px;
 }
 
 .login-logo {

--- a/users.json
+++ b/users.json
@@ -1,0 +1,8 @@
+{
+  "admin": {
+    "password": "whispad",
+    "is_admin": true,
+    "transcription_providers": ["openai", "local", "sensevoice"],
+    "postprocess_providers": ["openai"]
+  }
+}


### PR DESCRIPTION
## Summary
- manage allowed providers per user on the backend
- return provider info on login
- add checkbox groups in the user modal
- allow admins to edit providers for existing users
- filter configuration options based on allowed providers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870a6aab714832ea800debc0cc7e778