### PR TITLE
Make frontend model selection mandatory

### DIFF
--- a/app.js
+++ b/app.js
@@ -2716,7 +2716,7 @@ class NotesApp {
             const customPrompt = (style && style.custom) ? style.prompt : null;
             
             // Usar el backend en lugar de la API directamente
-            return await backendAPI.improveText(text, action, 'openai', false, null, customPrompt);
+            return await backendAPI.improveText(text, action, 'openai', false, this.config.postprocessModel, customPrompt);
         } catch (error) {
             throw new Error(`Error improving text with OpenAI: ${error.message}`);
         }
@@ -2730,7 +2730,7 @@ class NotesApp {
             const style = this.stylesConfig[action];
             const customPrompt = (style && style.custom) ? style.prompt : null;
             
-            const response = await backendAPI.improveText(text, action, 'openai', true, null, customPrompt);
+            const response = await backendAPI.improveText(text, action, 'openai', true, this.config.postprocessModel, customPrompt);
             
             if (!response.body) {
                 throw new Error('No response body received');
@@ -3697,10 +3697,6 @@ class NotesApp {
             }
         }
 
-        // Fallbacks for known providers
-        if (provider === 'openai' && models.length === 0) {
-            models = ['whisper-1', 'gpt-4o-mini-transcribe', 'gpt-4o-transcribe'];
-        }
 
         // Add options to dropdown
         models.forEach(model => {

--- a/backend-api.js
+++ b/backend-api.js
@@ -30,7 +30,7 @@ class BackendAPI {
         }
     }
 
-    async transcribeAudio(audioBlob, language = 'auto', model = 'whisper-1', provider = 'openai') {
+    async transcribeAudio(audioBlob, language = 'auto', model, provider = 'openai') {
         try {
             const formData = new FormData();
             
@@ -49,6 +49,9 @@ class BackendAPI {
             console.log('Audio blob type:', audioBlob.type, 'Using filename:', filename);
             
             formData.append('audio', audioBlob, filename);
+            if (!model) {
+                throw new Error('Model name required');
+            }
             formData.append('model', model);
             formData.append('provider', provider);
             
@@ -278,7 +281,7 @@ class BackendAPI {
             console.log('Options recibidas:', options);
             
             const {
-                model = 'gpt-4o-mini-transcribe',
+                model,
                 language = 'auto',
                 prompt = null,
                 responseFormat = 'json',
@@ -298,6 +301,9 @@ class BackendAPI {
                 stream = false;
             }
 
+            if (!model) {
+                throw new Error('Model name required');
+            }
             // Validar modelo
             if (!['gpt-4o-transcribe', 'gpt-4o-mini-transcribe'].includes(model)) {
                 throw new Error("Modelo no válido. Use 'gpt-4o-transcribe' o 'gpt-4o-mini-transcribe'");

--- a/note-transcribe-ai/app.js
+++ b/note-transcribe-ai/app.js
@@ -700,8 +700,9 @@ class NotesApp {
 
     async transcribeWithOpenAI(audioBlob) {
         try {
+            const model = this.config.transcriptionModel;
             // Usar el backend en lugar de la API directamente
-            return await backendAPI.transcribeAudio(audioBlob);
+            return await backendAPI.transcribeAudio(audioBlob, 'auto', model);
         } catch (error) {
             throw new Error(`Transcription error: ${error.message}`);
         }
@@ -825,7 +826,7 @@ class NotesApp {
             expandir: `Expande el siguiente texto añadiendo más detalles y contexto relevante. Elimina cualquier tipo de interjección o expresión propia del lenguaje oral (mmm, ahhh, eh, um, etc.) y expresiones de duda cuando se habla o piensa en voz alta:\n\n${text}`
         };
 
-        const model = this.config.postprocessModel || 'gpt-4o-mini';
+        const model = this.config.postprocessModel;
         
         // Aplicar configuración según el estilo de respuesta
         let temperature = this.config.temperature || 0.3;
@@ -884,7 +885,7 @@ class NotesApp {
             expandir: `Expande el siguiente texto añadiendo más detalles y contexto relevante. Elimina cualquier tipo de interjección o expresión propia del lenguaje oral (mmm, ahhh, eh, um, etc.) y expresiones de duda cuando se habla o piensa en voz alta:\n\n${text}`
         };
 
-        const model = this.config.postprocessModel || 'gemini-2.0-flash';
+        const model = this.config.postprocessModel;
         
         // Aplicar configuración según el estilo de respuesta
         let temperature = this.config.temperature || 0.3;


### PR DESCRIPTION
## Summary
- remove provider model fallbacks from the UI
- enforce explicit model parameters in frontend API calls
- require models for transcription and post-processing endpoints

## Testing
- `python3 test_dependencies.py` *(fails: missing dependencies)*
- `python3 -m py_compile backend.py`

------
https://chatgpt.com/codex/tasks/task_e_687150ca4ea0832eaa81ed1678359168