### PR TITLE
Use configured Gemini model in backend

### DIFF
--- a/app.js
+++ b/app.js
@@ -2812,7 +2812,7 @@ class NotesApp {
             const customPrompt = (style && style.custom) ? style.prompt : null;
             
             // Usar el backend en lugar de la API directamente
-            return await backendAPI.improveText(text, action, 'google', false, null, customPrompt);
+            return await backendAPI.improveText(text, action, 'google', false, this.config.postprocessModel, customPrompt);
         } catch (error) {
             throw new Error(`Error improving text with Gemini: ${error.message}`);
         }
@@ -2826,7 +2826,7 @@ class NotesApp {
             const style = this.stylesConfig[action];
             const customPrompt = (style && style.custom) ? style.prompt : null;
             
-            const response = await backendAPI.improveText(text, action, 'google', true, null, customPrompt);
+            const response = await backendAPI.improveText(text, action, 'google', true, this.config.postprocessModel, customPrompt);
             
             if (!response.body) {
                 throw new Error('No response body received');


### PR DESCRIPTION
## Summary
- respect selected postprocess model for Gemini
- pass the configured model from frontend calls

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68715a4cb1f0832eab3429f6907a9ba5