### PR TITLE
Fix think overlay text expansion

### DIFF
--- a/app.js
+++ b/app.js
@@ -3508,6 +3508,7 @@ class NotesApp {
         const overlay = document.getElementById('processing-overlay');
         const textElement = document.getElementById('processing-text');
         textElement.textContent = text;
+        textElement.scrollTop = textElement.scrollHeight;
         overlay.classList.add('active');
     }
 
@@ -3515,6 +3516,7 @@ class NotesApp {
         const textElement = document.getElementById('processing-text');
         if (textElement) {
             textElement.textContent = text;
+            textElement.scrollTop = textElement.scrollHeight;
         }
     }
     

--- a/note-transcribe-ai/app.js
+++ b/note-transcribe-ai/app.js
@@ -1134,6 +1134,7 @@ class NotesApp {
         const overlay = document.getElementById('processing-overlay');
         const textElement = document.getElementById('processing-text');
         textElement.textContent = text;
+        textElement.scrollTop = textElement.scrollHeight;
         overlay.classList.add('active');
     }
     

--- a/note-transcribe-ai/style.css
+++ b/note-transcribe-ai/style.css
@@ -1173,6 +1173,20 @@ select.form-control {
     font-weight: var(--font-weight-medium);
 }
 
+/* Container for streaming \<think\> content */
+#processing-text {
+    max-width: 80vw;
+    width: 100%;
+    max-height: 30vh;
+    overflow-y: auto;
+    padding: var(--space-8);
+    box-sizing: border-box;
+    white-space: pre-wrap;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-background);
+}
+
 /* Empty state */
 .empty-state {
     display: flex;

--- a/style.css
+++ b/style.css
@@ -1424,6 +1424,20 @@ select.form-control {
     font-weight: var(--font-weight-medium);
 }
 
+/* Container for streaming \<think\> content */
+#processing-text {
+    max-width: 80vw;
+    width: 100%;
+    max-height: 30vh;
+    overflow-y: auto;
+    padding: var(--space-8);
+    box-sizing: border-box;
+    white-space: pre-wrap;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-background);
+}
+
 /* Empty state */
 .empty-state {
     display: flex;


### PR DESCRIPTION
## Summary
- fix overlay text expansion by adding container styling for `#processing-text`
- scroll to bottom when updating streaming `think` text
- keep `note-transcribe-ai` frontend consistent

## Testing
- `python test_dependencies.py` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68722807d478832e8d333b0f58da07ca