### PR TITLE
Persist local provider configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ tmp/
 config.json
 settings.json
 user_config.json
+server_config.json
 
 # Archivos de API keys y tokens
 api_keys.txt

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ WhisPad is designed to persist your data between container restarts, updates, an
 
 ### Persistent Data
 - **Notes**: Stored in `./saved_notes/` (mounted to `/app/saved_notes` in container)
-- **Users**: Stored in `./users.json` (mounted to `/app/users.json` in container) 
+- **Users**: Stored in `./users.json` (mounted to `/app/users.json` in container)
+- **Provider Config**: Stored in `./server_config.json` (mounted to `/app/server_config.json` in container)
 - **Models**: Stored in `./whisper-cpp-models/` (mounted to `/app/whisper-cpp-models` in container)
 - **Logs**: Stored in `./logs/` (mounted to `/var/log/nginx` in container)
 

--- a/app.js
+++ b/app.js
@@ -666,6 +666,19 @@ class NotesApp {
 
         const storageKey = `notes-app-config-${currentUser}`;
         localStorage.setItem(storageKey, JSON.stringify(this.config));
+
+        if (isAdmin) {
+            authFetch('/api/update-provider-config', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    lmstudio_host: lmstudioHost,
+                    lmstudio_port: lmstudioPort,
+                    ollama_host: ollamaHost,
+                    ollama_port: ollamaPort
+                })
+            }).catch(() => {});
+        }
         this.updateMobileFabVisibility();
         this.hideConfigModal();
         this.showNotification('Configuration saved');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,5 @@ services:
       - ./saved_notes:/app/saved_notes
       - ./whisper-cpp-models:/app/whisper-cpp-models
       - ./users.json:/app/users.json
+      - ./server_config.json:/app/server_config.json
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- persist LM Studio and Ollama host/port in `server_config.json`
- expose `/api/update-provider-config` so admins can update these values
- propagate admin changes in the UI when saving configuration
- ignore `server_config.json` in git
- persist provider config in docker volume

## Testing
- `python -m py_compile backend.py`
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_687229efb694832e90a1a6e331ca5219