### PR TITLE
Add backup and security warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 WhisPad is a transcription and note management tool designed so anyone can turn their voice into text and easily organize their ideas. The application lets you use cloud models (OpenAI) or local whisper.cpp models to work offline.
 
+> **WARNING**
+> Always back up your notes before upgrading to a new version. Never expose the app to the internet without additional security measures.
+
 ## Table of Contents
 1. [Main Features](#main-features)
 2. [Disclaimer](#disclaimer)


### PR DESCRIPTION
## Summary
- remind users to back up notes before upgrading
- warn users not to expose WhisPad to the internet without extra security

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687264dc2034832eb802ccf894b69013