### PR TITLE
Add SenseVoice diarization support

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -504,6 +504,7 @@ def transcribe_audio():
             detect_emotion = request.form.get('detect_emotion', 'true').lower() == 'true'
             detect_events = request.form.get('detect_events', 'true').lower() == 'true'
             use_itn = request.form.get('use_itn', 'true').lower() == 'true'
+            speaker_diarization = request.form.get('speaker_diarization', 'false').lower() == 'true'
             
             result = sensevoice_wrapper.transcribe_audio_from_bytes(
                 audio_bytes,
@@ -511,7 +512,8 @@ def transcribe_audio():
                 language,
                 detect_emotion=detect_emotion,
                 detect_events=detect_events,
-                use_itn=use_itn
+                use_itn=use_itn,
+                speaker_diarization=speaker_diarization
             )
             
             if result.get('success'):
@@ -527,6 +529,8 @@ def transcribe_audio():
                     response_data["emotion"] = result.get('emotion')
                 if result.get('events'):
                     response_data["events"] = result.get('events')
+                if result.get('speaker_segments'):
+                    response_data["speaker_segments"] = result.get('speaker_segments')
                 
                 return jsonify(response_data)
             else:

--- a/test_sensevoice_direct.py
+++ b/test_sensevoice_direct.py
@@ -36,7 +36,8 @@ def test_sensevoice_direct():
             filename="test.wav",
             language="auto",
             detect_emotion=True,
-            detect_events=True
+            detect_events=True,
+            speaker_diarization=True
         )
         
         print("Transcription result:")
@@ -49,6 +50,10 @@ def test_sensevoice_direct():
                 print(f"Emotion: {result['emotion']}")
             if result.get('events'):
                 print(f"Events: {result['events']}")
+            if result.get("speaker_segments"):
+                print("Speaker segments:")
+                for seg in result["speaker_segments"]:
+                    print(seg)
         else:
             print(f"Error: {result.get('error', 'Unknown error')}")
             


### PR DESCRIPTION
## Summary
- enable optional speaker diarization in the SenseVoice wrapper
- expose diarization flag in backend API
- update test and example to show speaker segments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68726bd99474832eb099ccbc3a9d117b