### PR TITLE
Add streaming support for SenseVoice

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ WhisPad now includes **SenseVoice**, a state-of-the-art multilingual speech reco
 2. **Configure**: In "Config" → Select "SenseVoice" as your transcription provider
 3. **Customize**: Enable/disable emotion detection and audio event detection as needed
 4. **Transcribe**: Record audio and get enhanced transcriptions with emotional context
+5. **Real-Time Streaming**: When streaming is enabled in the configuration, SenseVoice transcribes audio chunks every few seconds so you see text while still recording
 
 ### Supported Languages
 - **Chinese**: Mandarin (zh), Cantonese (yue)


### PR DESCRIPTION
## Summary
- enable MediaRecorder timeslice when SenseVoice provider is streaming
- send audio chunks to backend for immediate transcription
- document new real-time SenseVoice streaming option

## Testing
- `python test_dependencies.py` *(fails: torchaudio, funasr, and other modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6872714b0744832ebd3af0e913493390