### PR TITLE
Add single user mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ WhisPad is designed to persist your data between container restarts, updates, an
 - **Default Admin**: Username `admin`, password `whispad`
 - **User Configuration**: Admins can create users and assign different transcription/postprocessing providers
 - **Per-User Folders**: Each user's notes are isolated in their own folder under `saved_notes/`
+- **Single User Mode**: Set `MULTI_USER=false` in `.env` or the compose file to skip the login screen and always use the admin account
 
 ### Initial Setup
 If you don't have a `data/users.json` file, the application will automatically create one with the default admin account. You can also copy `users.json.template` to `data/users.json` and customize it as needed.

--- a/app.js
+++ b/app.js
@@ -4125,6 +4125,16 @@ document.addEventListener('DOMContentLoaded', async () => {
     } else {
         currentUser = 'admin';
         isAdmin = true;
+        try {
+            const resp = await fetch('/api/session-info');
+            if (resp.ok) {
+                const data = await resp.json();
+                allowedTranscriptionProviders = data.transcription_providers || [];
+                allowedPostprocessProviders = data.postprocess_providers || [];
+            }
+        } catch (err) {
+            console.error('Error fetching session info:', err);
+        }
         await loadDefaultProviderConfig();
         currentUserBtn.classList.add('hidden');
         logoutBtn.classList.add('hidden');

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const POSTPROCESS_PROVIDERS = ['openai', 'google', 'openrouter', 'lmstudio', 'ol
 let allowedTranscriptionProviders = [];
 let allowedPostprocessProviders = [];
 let defaultProviderConfig = {};
+let multiUser = true;
 
 const PROVIDER_LABELS = {
     openai: 'OpenAI',
@@ -4023,7 +4024,7 @@ function initApp() {
     window.notesApp = new NotesApp();
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     const loginScreen = document.getElementById('login-screen');
     const appContent = document.getElementById('app-content');
     const loginBtn = document.getElementById('login-submit');
@@ -4032,6 +4033,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const togglePasswordBtn = document.getElementById('toggle-password');
     const currentUserBtn = document.getElementById('current-user-btn');
     const logoutBtn = document.getElementById('logout-btn');
+
+    try {
+        const resp = await fetch('/api/app-config');
+        if (resp.ok) {
+            const cfg = await resp.json();
+            multiUser = cfg.multi_user;
+        }
+    } catch (err) {
+        console.error('Error fetching app config:', err);
+    }
 
     async function loadDefaultProviderConfig() {
         try {
@@ -4109,7 +4120,19 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    restoreSession();
+    if (multiUser) {
+        restoreSession();
+    } else {
+        currentUser = 'admin';
+        isAdmin = true;
+        await loadDefaultProviderConfig();
+        currentUserBtn.classList.add('hidden');
+        logoutBtn.classList.add('hidden');
+        document.getElementById('user-btn').classList.add('hidden');
+        loginScreen.classList.add('hidden');
+        appContent.classList.remove('hidden');
+        initApp();
+    }
 
     async function attemptLogin() {
         const username = usernameInput.value.trim();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - LMSTUDIO_PORT=${LMSTUDIO_PORT:-1234}
       - OLLAMA_HOST=${OLLAMA_HOST:-127.0.0.1}
       - OLLAMA_PORT=${OLLAMA_PORT:-11434}
+      - MULTI_USER=${MULTI_USER:-true}
       - BACKEND_PORT=8000
       - CORS_ORIGINS=https://localhost:5037,https://127.0.0.1:5037
       - DEBUG=False

--- a/env.example
+++ b/env.example
@@ -20,6 +20,10 @@ LMSTUDIO_PORT=1234
 OLLAMA_HOST=127.0.0.1
 OLLAMA_PORT=11434
 
+# Set to false to disable multi-user support
+# When false, login/logout is skipped and the admin account is used automatically
+MULTI_USER=true
+
 # Optional: integration with a workflow agent (for example, n8n)
 # Set the URL of a webhook where saved notes will be sent
 WORKFLOW_WEBHOOK_URL=


### PR DESCRIPTION
## Summary
- make single-user mode configurable via `MULTI_USER` env var
- include new variable in compose and `.env` example
- expose `/api/app-config` for frontend
- bypass login screen and logout button when single-user mode is active
- document the new option in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ImportError while importing test module)*

------
https://chatgpt.com/codex/tasks/task_e_68729183c4e8832e8991f9e0f4bf2894