### PR TITLE
Implement voice note management

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ WhisPad is a transcription and note management tool designed so anyone can turn 
 - Write and edit markdown notes.
 - Integrated note manager: create, search, tag, save, restore and download in Markdown format.
 - Automatic text enhancement using AI (OpenAI, Google or OpenRouter) with streaming responses.
-- Optional saving of recorded audio together with its transcript.
+- Optional saving of recorded audio with its transcript and playback from each note.
 - A blue marker indicating where the transcription will be inserted.
 - Compatible with multiple providers: OpenAI, SenseVoice and local whisper.cpp. No model is bundled, but you can download tiny, small, base, medium or large versions from the interface.
 - **NEW: SenseVoice Integration** - Advanced multilingual speech recognition with emotion detection and audio event recognition for 50+ languages.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ WhisPad is a transcription and note management tool designed so anyone can turn 
 - Write and edit markdown notes.
 - Integrated note manager: create, search, tag, save, restore and download in Markdown format.
 - Automatic text enhancement using AI (OpenAI, Google or OpenRouter) with streaming responses.
-- Optional saving of recorded audio with its transcript and playback from each note.
+- Optional saving of recorded audio with its transcript and playback from each note. Recordings are converted to MP3 for broad browser support.
 - A blue marker indicating where the transcription will be inserted.
 - Compatible with multiple providers: OpenAI, SenseVoice and local whisper.cpp. No model is bundled, but you can download tiny, small, base, medium or large versions from the interface.
 - **NEW: SenseVoice Integration** - Advanced multilingual speech recognition with emotion detection and audio event recognition for 50+ languages.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ WhisPad is a transcription and note management tool designed so anyone can turn 
 - Write and edit markdown notes.
 - Integrated note manager: create, search, tag, save, restore and download in Markdown format.
 - Automatic text enhancement using AI (OpenAI, Google or OpenRouter) with streaming responses.
+- Optional saving of recorded audio together with its transcript.
 - A blue marker indicating where the transcription will be inserted.
 - Compatible with multiple providers: OpenAI, SenseVoice and local whisper.cpp. No model is bundled, but you can download tiny, small, base, medium or large versions from the interface.
 - **NEW: SenseVoice Integration** - Advanced multilingual speech recognition with emotion detection and audio event recognition for 50+ languages.

--- a/app.js
+++ b/app.js
@@ -4072,8 +4072,15 @@ class NotesApp {
             const audio = document.createElement('audio');
             audio.controls = true;
             const tokenParam = authToken ? `?token=${encodeURIComponent(authToken)}` : '';
-            audio.src = `/recordings/${currentUser}/${item.file}${tokenParam}`;
+            const encodedUser = encodeURIComponent(currentUser);
+            const encodedFile = encodeURIComponent(item.file);
+            audio.src = `/recordings/${encodedUser}/${encodedFile}${tokenParam}`;
+            audio.type = 'audio/mpeg';
             audio.preload = 'none';
+            audio.addEventListener('error', () => {
+                audio.title = 'Failed to load audio';
+                audio.classList.add('error');
+            });
             wrapper.appendChild(audio);
             if (item.timestamp) {
                 const tsStr = formatTimestamp(item.timestamp);

--- a/app.js
+++ b/app.js
@@ -4071,9 +4071,19 @@ class NotesApp {
             wrapper.className = 'audio-item';
             const audio = document.createElement('audio');
             audio.controls = true;
-            audio.src = `/recordings/${currentUser}/${item.file}`;
+            const tokenParam = authToken ? `?token=${encodeURIComponent(authToken)}` : '';
+            audio.src = `/recordings/${currentUser}/${item.file}${tokenParam}`;
             audio.preload = 'none';
             wrapper.appendChild(audio);
+            if (item.timestamp) {
+                const tsStr = formatTimestamp(item.timestamp);
+                if (tsStr) {
+                    const tsEl = document.createElement('div');
+                    tsEl.className = 'timestamp';
+                    tsEl.textContent = tsStr;
+                    wrapper.appendChild(tsEl);
+                }
+            }
             if (item.transcript) {
                 const p = document.createElement('p');
                 p.textContent = item.transcript;
@@ -4135,6 +4145,19 @@ class NotesApp {
             this.autoSaveInterval = null;
         }
     }
+}
+
+function formatTimestamp(ts) {
+    if (!ts || ts.length < 14) return '';
+    const year = ts.slice(0, 4);
+    const month = ts.slice(4, 6);
+    const day = ts.slice(6, 8);
+    const hour = ts.slice(8, 10);
+    const minute = ts.slice(10, 12);
+    const second = ts.slice(12, 14);
+    const d = new Date(`${year}-${month}-${day}T${hour}:${minute}:${second}`);
+    if (isNaN(d)) return '';
+    return d.toLocaleString();
 }
 
 // Inicializar la aplicación cuando se carga la página

--- a/backend.py
+++ b/backend.py
@@ -2102,7 +2102,9 @@ def delete_audio():
 
 @app.route('/recordings/<username>/<path:fname>')
 def get_recording(username, fname):
-    current = get_current_username()
+    """Serve a recorded audio file, allowing token via query string"""
+    token = request.headers.get('Authorization') or request.args.get('token')
+    current = SESSIONS.get(token) if token else None
     if not current:
         return jsonify({"error": "Unauthorized"}), 401
     if current != username and not USERS.get(current, {}).get('is_admin'):

--- a/backend.py
+++ b/backend.py
@@ -15,6 +15,7 @@ from datetime import datetime
 import shutil
 from whisper_cpp_wrapper import WhisperCppWrapper
 from sensevoice_wrapper import get_sensevoice_wrapper
+from pydub import AudioSegment
 import threading
 
 # Cargar variables de entorno
@@ -2012,6 +2013,16 @@ def save_audio():
     filename = f"{note_id}-{ts}{ext}"
     path = os.path.join(audio_dir, filename)
     audio_file.save(path)
+
+    mp3_filename = f"{note_id}-{ts}.mp3"
+    mp3_path = os.path.join(audio_dir, mp3_filename)
+    try:
+        AudioSegment.from_file(path).export(mp3_path, format='mp3')
+        os.remove(path)
+        filename = mp3_filename
+        path = mp3_path
+    except Exception as e:
+        print(f"Error converting audio to MP3: {e}")
 
     md_path = find_existing_note_file(user_dir, note_id)
     if not md_path:

--- a/index.html
+++ b/index.html
@@ -168,6 +168,14 @@
                         </button>
                     </div>
                 </div>
+                <div class="toolbar-section">
+                    <h3>Audio</h3>
+                    <div class="audio-controls">
+                        <button class="btn btn--outline btn--sm" id="voice-notes-btn">
+                            <i class="fas fa-headphones"></i>&nbsp;Voice notes
+                        </button>
+                    </div>
+                </div>
             </div>
             
             <!-- Editing area -->
@@ -479,6 +487,16 @@
                         </label>
                     </div>
                 </div>
+                <h4 class="config-group-title">Audio files</h4>
+                <div class="config-section">
+                    <div class="checkbox-group">
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="save-voice-notes">
+                            <span class="checkmark"></span>
+                            Enable saving voice-notes
+                        </label>
+                    </div>
+                </div>
             </div>
             <div class="modal-actions">
                 <button class="btn btn--outline" id="cancel-config">Cancel</button>
@@ -590,6 +608,17 @@
             
             <div class="modal-actions">
                 <button class="btn btn--outline" id="cancel-upload-models">Close</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Voice notes modal -->
+    <div class="modal" id="voice-notes-modal">
+        <div class="modal-content">
+            <h3>Voice Notes</h3>
+            <div id="voice-notes-list" class="voice-notes-list"></div>
+            <div class="modal-actions">
+                <button class="btn btn--outline" id="close-voice-notes">Close</button>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -493,7 +493,7 @@
                         <label class="checkbox-label">
                             <input type="checkbox" id="save-voice-notes">
                             <span class="checkmark"></span>
-                            Enable saving voice-notes
+                            Enable saving voice-notes (stored as MP3)
                         </label>
                     </div>
                 </div>

--- a/style.css
+++ b/style.css
@@ -2497,6 +2497,10 @@ select.form-control {
     margin-bottom: var(--space-4);
 }
 
+.voice-notes-list audio.error {
+    border: 2px solid var(--color-danger);
+}
+
 .voice-notes-list .timestamp {
     font-size: 0.8rem;
     color: var(--color-text-secondary);

--- a/style.css
+++ b/style.css
@@ -2481,3 +2481,18 @@ select.form-control {
 .user-item:last-child {
     border-bottom: none;
 }
+
+.audio-controls {
+    display: flex;
+    gap: var(--space-8);
+    margin-bottom: var(--space-12);
+}
+
+.voice-notes-list .audio-item {
+    margin-bottom: var(--space-12);
+}
+
+.voice-notes-list audio {
+    width: 100%;
+    margin-bottom: var(--space-4);
+}

--- a/style.css
+++ b/style.css
@@ -2496,3 +2496,9 @@ select.form-control {
     width: 100%;
     margin-bottom: var(--space-4);
 }
+
+.voice-notes-list .timestamp {
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+    margin-bottom: var(--space-4);
+}


### PR DESCRIPTION
## Summary
- add optional saving of voice notes in configuration
- support playback and deletion of audio files per note
- implement backend endpoints for audio save/list/delete and serving files
- add audio management UI and styles
- document new voice note capability

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68729cd48618832e878c79cad0b71492