### PR TITLE
Add real-time local Whisper option

### DIFF
--- a/app.js
+++ b/app.js
@@ -114,7 +114,6 @@ class NotesApp {
         this.insertionRange = null;
         this.mediaRecorder = null;
         this.audioChunks = [];
-        this.realtimeIntervalId = null;
         
         // History to undo AI changes
         this.aiHistory = [];
@@ -2278,18 +2277,9 @@ class NotesApp {
                     }
                 };
                 this.mediaRecorder.onstop = () => {
-                    if (this.realtimeIntervalId) {
-                        clearInterval(this.realtimeIntervalId);
-                        this.realtimeIntervalId = null;
-                    }
                     stream.getTracks().forEach(track => track.stop());
                 };
-                this.mediaRecorder.start();
-                this.realtimeIntervalId = setInterval(() => {
-                    if (this.mediaRecorder && this.mediaRecorder.state === 'recording') {
-                        try { this.mediaRecorder.requestData(); } catch (e) { console.error('requestData error', e); }
-                    }
-                }, this.config.localInterval * 1000);
+                this.mediaRecorder.start(this.config.localInterval * 1000);
             } else {
                 this.mediaRecorder.ondataavailable = (event) => {
                     this.audioChunks.push(event.data);
@@ -2330,10 +2320,6 @@ class NotesApp {
 
     stopRecording() {
         if (this.mediaRecorder && this.isRecording) {
-            if (this.realtimeIntervalId) {
-                clearInterval(this.realtimeIntervalId);
-                this.realtimeIntervalId = null;
-            }
             this.mediaRecorder.stop();
             this.isRecording = false;
             

--- a/app.js
+++ b/app.js
@@ -114,6 +114,7 @@ class NotesApp {
         this.insertionRange = null;
         this.mediaRecorder = null;
         this.audioChunks = [];
+        this.realtimeIntervalId = null;
         
         // History to undo AI changes
         this.aiHistory = [];
@@ -2277,9 +2278,18 @@ class NotesApp {
                     }
                 };
                 this.mediaRecorder.onstop = () => {
+                    if (this.realtimeIntervalId) {
+                        clearInterval(this.realtimeIntervalId);
+                        this.realtimeIntervalId = null;
+                    }
                     stream.getTracks().forEach(track => track.stop());
                 };
-                this.mediaRecorder.start(this.config.localInterval * 1000);
+                this.mediaRecorder.start();
+                this.realtimeIntervalId = setInterval(() => {
+                    if (this.mediaRecorder && this.mediaRecorder.state === 'recording') {
+                        try { this.mediaRecorder.requestData(); } catch (e) { console.error('requestData error', e); }
+                    }
+                }, this.config.localInterval * 1000);
             } else {
                 this.mediaRecorder.ondataavailable = (event) => {
                     this.audioChunks.push(event.data);
@@ -2320,6 +2330,10 @@ class NotesApp {
 
     stopRecording() {
         if (this.mediaRecorder && this.isRecording) {
+            if (this.realtimeIntervalId) {
+                clearInterval(this.realtimeIntervalId);
+                this.realtimeIntervalId = null;
+            }
             this.mediaRecorder.stop();
             this.isRecording = false;
             

--- a/index.html
+++ b/index.html
@@ -373,6 +373,20 @@
                             </label>
                         </div>
                     </div>
+                    <div class="model-config restricted-option" id="local-options" style="display: none;">
+                        <label class="form-label">Local Whisper</label>
+                        <div class="checkbox-group">
+                            <label class="checkbox-label">
+                                <input type="checkbox" id="local-realtime">
+                                <span class="checkmark"></span>
+                                Real-time transcription
+                            </label>
+                            <div id="local-interval-container" style="display:none;margin-top:5px;">
+                                <label class="form-label">Interval (seconds)</label>
+                                <input type="number" class="form-control" id="local-interval" min="1" value="2">
+                            </div>
+                        </div>
+                    </div>
                 </div>
 
                 <h4 class="config-group-title">Post-processing Configuration</h4>


### PR DESCRIPTION
## Summary
- add UI inputs for local Whisper real-time transcription
- persist new config values
- record audio in slices for local real-time mode
- show/hide options based on provider selection
- skip overlays when streaming locally

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68737de5c4d4832e8e87abed4c5439eb