### PR TITLE
Add toggleable sidebars with custom prompt feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 WhisPad is a transcription and note management tool designed so anyone can turn their voice into text and easily organize their ideas. The application lets you use cloud models (OpenAI) or local whisper.cpp models to work offline.
 
 > **WARNING**
-> Always back up your notes before upgrading to a new version. Never expose the app to the internet without additional security measures.
+> Always back up your notes before upgrading to a new version. **NEVER** expose the app to the internet without additional security measures.
 
 ## Table of Contents
 1. [Main Features](#main-features)

--- a/app.js
+++ b/app.js
@@ -207,7 +207,11 @@ class NotesApp {
         }
         // Toggle con hamburguesa
         hamburger.addEventListener('click', () => {
-            sidebar.classList.toggle('active');
+            if (window.innerWidth <= 900) {
+                sidebar.classList.toggle('active');
+            } else {
+                sidebar.classList.toggle('desktop-hidden');
+            }
         });
         // Cerrar sidebar al hacer click fuera (opcional)
         document.addEventListener('click', (e) => {
@@ -219,8 +223,6 @@ class NotesApp {
         // Opcional: cerrar al cambiar tamaño de pantalla
         window.addEventListener('resize', () => {
             if (window.innerWidth > 900) {
-                sidebar.classList.add('active');
-            } else {
                 sidebar.classList.remove('active');
             }
         });
@@ -441,6 +443,40 @@ class NotesApp {
         if (updateOllamaBtn) {
             updateOllamaBtn.addEventListener('click', () => {
                 this.updateOllamaModelsList();
+            });
+        }
+
+        // Custom prompt sidebar
+        const promptSidebar = document.getElementById('prompt-sidebar');
+        const promptToggle = document.getElementById('prompt-sidebar-toggle');
+        const applyPromptBtn = document.getElementById('apply-custom-prompt');
+        const customPromptInput = document.getElementById('custom-prompt-text');
+
+        if (promptToggle && promptSidebar) {
+            promptToggle.addEventListener('click', () => {
+                promptSidebar.classList.toggle('active');
+            });
+        }
+
+        if (applyPromptBtn && customPromptInput) {
+            applyPromptBtn.addEventListener('click', () => {
+                const prompt = customPromptInput.value.trim();
+                if (!prompt) {
+                    this.showNotification('Please enter a prompt', 'warning');
+                    return;
+                }
+                const finalPrompt = `${prompt}\n\nIMPORTANT SYSTEM PROMPT: you must not add any additional comments. Simply follow the previous prompt as instructed and answer in the previous language.`;
+                const tempKey = 'temp_custom_prompt';
+                this.stylesConfig[tempKey] = {
+                    nombre: 'Custom',
+                    descripcion: 'Temporary prompt',
+                    icono: '💬',
+                    prompt: finalPrompt,
+                    visible: true,
+                    custom: true
+                };
+                this.improveText(tempKey);
+                delete this.stylesConfig[tempKey];
             });
         }
         

--- a/index.html
+++ b/index.html
@@ -93,6 +93,9 @@
             </button>
             <button class="btn btn--outline btn--sm hidden" id="current-user-btn"></button>
             <button class="btn btn--error btn--sm hidden" id="logout-btn">Logout</button>
+            <button class="btn btn--outline btn--sm" id="prompt-sidebar-toggle" title="Custom prompt">
+                <i class="fas fa-terminal"></i>&nbsp;Prompt
+            </button>
             <button class="hamburger-menu" id="hamburger-menu" aria-label="Show/Hide notes menu">
                 <span></span><span></span><span></span>
             </button>
@@ -223,8 +226,12 @@
                 </div>
             </div>
         </div>
+        <div class="prompt-sidebar" id="prompt-sidebar">
+            <textarea id="custom-prompt-text" rows="6" placeholder="Enter custom prompt..."></textarea>
+            <button class="btn btn--primary btn--sm" id="apply-custom-prompt" style="margin-top: 10px;">Apply</button>
+        </div>
     </div>
-    
+
     <!-- Confirmation modal -->
     <div class="modal" id="delete-modal">
         <div class="modal-content">

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 /* Hamburger menu styles */
 .hamburger-menu {
-  display: none;
+  display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
@@ -60,7 +60,7 @@
 
 @media (min-width: 901px) {
   .hamburger-menu {
-    display: none !important;
+    display: flex !important;
   }
   .sidebar {
     position: relative;
@@ -2480,4 +2480,32 @@ select.form-control {
 
 .user-item:last-child {
     border-bottom: none;
+}
+
+/* Desktop sidebar toggle */
+.sidebar.desktop-hidden {
+    display: none;
+}
+
+/* Custom prompt sidebar */
+.prompt-sidebar {
+    width: 320px;
+    background-color: var(--color-surface);
+    border-left: 1px solid var(--color-border);
+    display: none;
+    flex-direction: column;
+    padding: var(--space-16);
+}
+
+.prompt-sidebar.active {
+    display: flex;
+}
+
+.prompt-sidebar textarea {
+    width: 100%;
+    resize: vertical;
+}
+
+.prompt-sidebar button {
+    margin-top: var(--space-16);
 }


### PR DESCRIPTION
## Summary
- allow hamburger menu on desktop and hide notes sidebar using `.desktop-hidden`
- add new right-side prompt sidebar with textarea and Apply button
- include toggle button in header
- implement JS logic for sidebar toggling and applying temporary prompts
- append system message automatically to custom prompts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873aa8c5304832e9a0a1fe7e99f985e