### PR TITLE
Add custom prompt sidebar and preserve text on refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,9 @@
             </button>
             <button class="btn btn--outline btn--sm hidden" id="current-user-btn"></button>
             <button class="btn btn--error btn--sm hidden" id="logout-btn">Logout</button>
+            <button class="btn btn--outline btn--sm" id="prompt-sidebar-toggle" title="Custom prompt">
+                <i class="fas fa-terminal"></i>&nbsp;Prompt
+            </button>
             <button class="hamburger-menu" id="hamburger-menu" aria-label="Show/Hide notes menu">
                 <span></span><span></span><span></span>
             </button>
@@ -223,8 +226,12 @@
                 </div>
             </div>
         </div>
+        <div class="prompt-sidebar" id="prompt-sidebar">
+            <textarea id="custom-prompt-text" rows="6" placeholder="Enter custom prompt..."></textarea>
+            <button class="btn btn--primary btn--sm" id="apply-custom-prompt" style="margin-top: 10px;">Apply</button>
+        </div>
     </div>
-    
+
     <!-- Confirmation modal -->
     <div class="modal" id="delete-modal">
         <div class="modal-content">

--- a/index.html
+++ b/index.html
@@ -93,9 +93,6 @@
             </button>
             <button class="btn btn--outline btn--sm hidden" id="current-user-btn"></button>
             <button class="btn btn--error btn--sm hidden" id="logout-btn">Logout</button>
-            <button class="btn btn--outline btn--sm" id="prompt-sidebar-toggle" title="Custom prompt">
-                <i class="fas fa-terminal"></i>&nbsp;Prompt
-            </button>
             <button class="hamburger-menu" id="hamburger-menu" aria-label="Show/Hide notes menu">
                 <span></span><span></span><span></span>
             </button>
@@ -150,6 +147,9 @@
                     </button>
                     <button class="btn btn--outline btn--sm" id="styles-config-btn" title="Configure enhancement styles">
                         <i class="fas fa-palette"></i>&nbsp;Styles
+                    </button>
+                    <button class="btn btn--outline btn--sm" id="prompt-sidebar-toggle" title="Custom prompt">
+                        <i class="fas fa-terminal"></i>&nbsp;Prompt
                     </button>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 /* Hamburger menu styles */
 .hamburger-menu {
-  display: none;
+  display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
@@ -60,7 +60,7 @@
 
 @media (min-width: 901px) {
   .hamburger-menu {
-    display: none !important;
+    display: flex !important;
   }
   .sidebar {
     position: relative;
@@ -2480,4 +2480,32 @@ select.form-control {
 
 .user-item:last-child {
     border-bottom: none;
+}
+
+/* Desktop sidebar toggle */
+.sidebar.desktop-hidden {
+    display: none;
+}
+
+/* Custom prompt sidebar */
+.prompt-sidebar {
+    width: 320px;
+    background-color: var(--color-surface);
+    border-left: 1px solid var(--color-border);
+    display: none;
+    flex-direction: column;
+    padding: var(--space-16);
+}
+
+.prompt-sidebar.active {
+    display: flex;
+}
+
+.prompt-sidebar textarea {
+    width: 100%;
+    resize: vertical;
+}
+
+.prompt-sidebar button {
+    margin-top: var(--space-16);
 }


### PR DESCRIPTION
## Summary
- allow hiding notes sidebar on desktop
- add collapsible prompt sidebar with textarea and Apply button
- append system prompt when applying custom prompt
- preserve in-progress text with localStorage backup

## Testing
- `pip install -r requirements.txt` *(failed: ModuleNotFoundError: No module named 'requests')*
- `pytest -q` *(failed: ImportError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_6873aa8c5304832e9a0a1fe7e99f985e