### PR TITLE
Ensure plain text paste

### DIFF
--- a/app.js
+++ b/app.js
@@ -318,6 +318,13 @@ class NotesApp {
         editor.addEventListener('input', () => {
             this.handleEditorChange();
         });
+
+        // Handle paste events to ensure plain text insertion
+        editor.addEventListener('paste', (e) => {
+            e.preventDefault();
+            const text = (e.clipboardData || window.clipboardData).getData('text/plain');
+            document.execCommand('insertText', false, text);
+        });
         
         // Selección de texto en el editor
         editor.addEventListener('mouseup', () => {


### PR DESCRIPTION
## Summary
- handle paste events so text editor strips formatting
- keep pasted text plain

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873bb54d610832e94e064d9579ff73e