### PR TITLE
Add chat sidebar for AI conversations

### DIFF
--- a/app.js
+++ b/app.js
@@ -123,6 +123,7 @@ class NotesApp {
 
         // Chat conversation history
         this.chatMessages = [];
+        this.chatNote = '';
         
         // Provider configuration
         this.config = {
@@ -525,6 +526,7 @@ class NotesApp {
         if (chatNew) {
             chatNew.addEventListener('click', () => {
                 this.chatMessages = [];
+                this.chatNote = '';
                 this.renderChatMessages();
             });
         }
@@ -4123,6 +4125,12 @@ class NotesApp {
         const container = document.getElementById('chat-messages');
         if (!container) return;
         container.innerHTML = '';
+        if (this.chatNote) {
+            const noteDiv = document.createElement('div');
+            noteDiv.className = 'chat-message system';
+            noteDiv.textContent = this.chatNote;
+            container.appendChild(noteDiv);
+        }
         this.chatMessages.forEach(msg => {
             const div = document.createElement('div');
             div.className = `chat-message ${msg.role}`;
@@ -4145,6 +4153,8 @@ class NotesApp {
         } else if (addSelected) {
             noteText = this.selectedText || '';
         }
+
+        this.chatNote = noteText;
 
         this.chatMessages.push({ role: 'user', content: text });
         this.renderChatMessages();

--- a/index.html
+++ b/index.html
@@ -239,15 +239,15 @@
                     <label><input type="checkbox" id="chat-add-full"> Add full note</label>
                     <label><input type="checkbox" id="chat-add-selected"> Add selected text</label>
                 </div>
-                <button class="btn btn--outline btn--sm" id="chat-new" title="New chat">
-                    <i class="fas fa-plus"></i>
-                </button>
             </div>
             <div class="chat-messages" id="chat-messages"></div>
             <div class="chat-input">
-                <input type="text" id="chat-message-input" placeholder="Type a message...">
+                <textarea id="chat-message-input" rows="3" placeholder="Type a message..."></textarea>
                 <button class="btn btn--primary btn--sm" id="chat-send" title="Send">
                     <i class="fas fa-paper-plane"></i>
+                </button>
+                <button class="btn btn--outline btn--sm" id="chat-new" title="New chat">
+                    <i class="fas fa-plus"></i>
                 </button>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -151,6 +151,9 @@
                     <button class="btn btn--outline btn--sm" id="prompt-sidebar-toggle" title="Custom prompt">
                         <i class="fas fa-terminal"></i>&nbsp;Prompt
                     </button>
+                    <button class="btn btn--outline btn--sm" id="chat-sidebar-toggle" title="Chat assistant">
+                        <i class="fas fa-comments"></i>&nbsp;Chat
+                    </button>
                 </div>
             </div>
                 
@@ -229,6 +232,24 @@
         <div class="prompt-sidebar" id="prompt-sidebar">
             <textarea id="custom-prompt-text" rows="6" placeholder="Enter custom prompt..."></textarea>
             <button class="btn btn--primary btn--sm" id="apply-custom-prompt" style="margin-top: 10px;">Apply</button>
+        </div>
+        <div class="chat-sidebar" id="chat-sidebar">
+            <div class="chat-header">
+                <div class="checkbox-group">
+                    <label><input type="checkbox" id="chat-add-full"> Add full note</label>
+                    <label><input type="checkbox" id="chat-add-selected"> Add selected text</label>
+                </div>
+                <button class="btn btn--outline btn--sm" id="chat-new" title="New chat">
+                    <i class="fas fa-plus"></i>
+                </button>
+            </div>
+            <div class="chat-messages" id="chat-messages"></div>
+            <div class="chat-input">
+                <input type="text" id="chat-message-input" placeholder="Type a message...">
+                <button class="btn btn--primary btn--sm" id="chat-send" title="Send">
+                    <i class="fas fa-paper-plane"></i>
+                </button>
+            </div>
         </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -2530,8 +2530,11 @@ select.form-control {
     border-bottom: 1px solid var(--color-border);
 }
 
+
 .chat-messages {
     flex: 1;
+    display: flex;
+    flex-direction: column;
     overflow-y: auto;
     padding: var(--space-16);
 }
@@ -2539,8 +2542,10 @@ select.form-control {
 .chat-message {
     margin-bottom: var(--space-8);
     padding: var(--space-8);
-    border-radius: 4px;
+    border-radius: 8px;
     word-break: break-word;
+    max-width: 80%;
+    color: #000;
 }
 
 .chat-message.user {

--- a/style.css
+++ b/style.css
@@ -2509,3 +2509,60 @@ select.form-control {
 .prompt-sidebar button {
     margin-top: var(--space-16);
 }
+
+/* Chat sidebar */
+.chat-sidebar {
+    width: 320px;
+    background-color: var(--color-surface);
+    border-left: 1px solid var(--color-border);
+    display: none;
+    flex-direction: column;
+}
+
+.chat-sidebar.active {
+    display: flex;
+}
+
+.chat-header {
+    display: flex;
+    justify-content: space-between;
+    padding: var(--space-16);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.chat-messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-16);
+}
+
+.chat-message {
+    margin-bottom: var(--space-8);
+    padding: var(--space-8);
+    border-radius: 4px;
+    word-break: break-word;
+}
+
+.chat-message.user {
+    background-color: #e0e0e0;
+    align-self: flex-end;
+}
+
+.chat-message.assistant {
+    background-color: #d1eaff;
+    align-self: flex-start;
+}
+
+.chat-input {
+    display: flex;
+    padding: var(--space-16);
+    border-top: 1px solid var(--color-border);
+}
+
+.chat-input input {
+    flex: 1;
+}
+
+.chat-input button {
+    margin-left: var(--space-8);
+}

--- a/style.css
+++ b/style.css
@@ -2559,8 +2559,12 @@ select.form-control {
     border-top: 1px solid var(--color-border);
 }
 
-.chat-input input {
+
+.chat-input textarea {
     flex: 1;
+    height: 60px;
+    resize: vertical;
+    padding: var(--space-8);
 }
 
 .chat-input button {

--- a/style.css
+++ b/style.css
@@ -2558,6 +2558,12 @@ select.form-control {
     align-self: flex-start;
 }
 
+.chat-message.system {
+    background-color: #f5f5f5;
+    align-self: center;
+    font-style: italic;
+}
+
 .chat-input {
     display: flex;
     padding: var(--space-16);


### PR DESCRIPTION
## Summary
- add Chat button alongside Prompt button
- create chat sidebar with message bubbles and input UI
- wire up chat interactions with streaming backend
- extend backend `/api/improve-text` to handle chat payloads
- add provider-specific streaming chat helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c11ae990832e940c14c2eaaae237