### PR TITLE
Secure DB credentials and admin account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,8 +117,7 @@ whisper.cpp/
 whisper_models/
 
 # User data and configuration (persisted via Docker volumes)
-# users.json - uncomment the line below if you want to keep user data in git
-# users.json
+data/users.json
 
 # Archivos de desarrollo y testing
 .pytest_cache/

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you are not comfortable with the terminal, the easiest method is to use **Doc
    docker compose up
    ```
 4. Docker will download the dependencies and show *"Starting services..."*. When everything is ready, open your browser at `https://localhost:5037`.
-5. Sign in with **admin** / **whispad** the first time to access the app.
+5. Sign in with **admin** and the password from `ADMIN_PASSWORD` the first time to access the app.
 6. To stop the application, press `Ctrl+C` in the terminal or use the *Stop* button in Docker Desktop.
 
 ## Installing with Docker Desktop
@@ -64,7 +64,7 @@ This option is ideal if you don't want to worry about installing Python or depen
    docker compose up
    ```
 4. Go to `https://localhost:5037` and start using WhisPad.
-5. Log in with **admin** / **whispad** on first use.
+5. Log in with **admin** using the password from `ADMIN_PASSWORD` on first use.
 6. To stop it, press `Ctrl+C` in the terminal or run `docker compose down`.
 7. If you want to use LM Studio or Ollama for local AI text improvement, set the host to
    `host.docker.internal` in the configuration page so the container can reach
@@ -95,7 +95,7 @@ If you prefer not to use Docker, you can also run it directly with Python:
    python backend.py
    ```
 6. Open `index.html` in your browser or serve the folder with `python -m http.server 5037` and visit `https://localhost:5037`.
-7. Log in with **admin** / **whispad** the first time you access the app.
+7. Log in with **admin** using the password from `ADMIN_PASSWORD` the first time you access the app.
 
 ## API Key Configuration
 Copy `env.example` to `.env` and add your API keys:
@@ -105,7 +105,9 @@ cp env.example .env
 Edit the `.env` file and fill in the variables `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `DEEPSEEK_API_KEY` and `OPENROUTER_API_KEY` for the services you want to use. These keys enable cloud transcription and text enhancement.
 If you want to send each saved note to an external workflow (for example, an n8n or Dify instance), also set `WORKFLOW_WEBHOOK_URL` and optionally `WORKFLOW_WEBHOOK_TOKEN`.
 Use `WORKFLOW_WEBHOOK_USER` to choose which user's notes are sent. The webhook payload now includes the username so your workflow can fetch the note from the correct folder.
-Set `DATABASE_URL` if you want to override the default PostgreSQL connection string.
+Set the database credentials in your `.env` file using `POSTGRES_USER`, `POSTGRES_PASSWORD` and `POSTGRES_DB`.
+`DATABASE_URL` should point to `postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}`.
+Set `ADMIN_PASSWORD` to define the initial admin user's password.
 
 ## Usage Guide
 1. Press the microphone button to record audio and get real-time transcription.
@@ -129,15 +131,15 @@ WhisPad is designed to persist your data between container restarts, updates, an
 - **Logs**: Stored in `./logs/` (mounted to `/var/log/nginx` in container)
 
 ### User Management
-- **Default Admin**: Username `admin`, password `whispad`
+- **Default Admin**: Username `admin`, password set via `ADMIN_PASSWORD`
 - **User Configuration**: Admins can create users and assign different transcription/postprocessing providers
 - **Per-User Folders**: Each user's notes are isolated in their own folder under `saved_notes/`
 - **Single User Mode**: Set `MULTI_USER=false` in `.env` or the compose file to skip the login screen and always use the admin account
 
 ### Initial Setup
-On first start the backend migrates any existing `data/users.json` file to the PostgreSQL database automatically and creates the default admin if necessary.
+On first start the backend creates the `admin` user using the password from `ADMIN_PASSWORD`.
 
-**Important**: Change the default admin password immediately after first login for security!
+**Important**: Change the admin password immediately after first login for security!
 
 ## Screenshots
 

--- a/backend.py
+++ b/backend.py
@@ -110,11 +110,15 @@ HASHER = PasswordHasher(time_cost=2, memory_cost=65536, parallelism=2, hash_len=
 init_db()
 migrate_json(hasher=HASHER)
 
+ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD")
+if not ADMIN_PASSWORD:
+    raise RuntimeError("ADMIN_PASSWORD environment variable not set")
+
 def ensure_admin_user():
     if not get_user('admin'):
         db_create_user(
             'admin',
-            HASHER.hash('whispad'),
+            HASHER.hash(ADMIN_PASSWORD),
             True,
             ALL_TRANSCRIPTION_PROVIDERS,
             ALL_POSTPROCESS_PROVIDERS,

--- a/data/users.json
+++ b/data/users.json
@@ -1,8 +1,0 @@
-{
-  "admin": {
-    "password": "whispad",
-    "is_admin": true,
-    "transcription_providers": ["openai", "local", "sensevoice"],
-    "postprocess_providers": ["openai", "google", "openrouter", "lmstudio", "ollama"]
-  }
-}

--- a/db.py
+++ b/db.py
@@ -2,7 +2,9 @@ import os
 import json
 from psycopg_pool import ConnectionPool
 
-DB_DSN = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/whispad")
+DB_DSN = os.getenv("DATABASE_URL")
+if not DB_DSN:
+    raise RuntimeError("DATABASE_URL environment variable not set")
 
 pool = ConnectionPool(conninfo=DB_DSN, min_size=1, max_size=5)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - BACKEND_PORT=8000
       - CORS_ORIGINS=https://localhost:5037,https://127.0.0.1:5037
       - DEBUG=False
-      - DATABASE_URL=postgresql://whispad:whispad@db:5432/whispad
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
     depends_on:
       - db
     volumes:
@@ -30,11 +30,9 @@ services:
   db:
     image: postgres:16
     environment:
-      POSTGRES_USER: whispad
-      POSTGRES_PASSWORD: whispad
-      POSTGRES_DB: whispad
-    ports:
-      - "5432:5432"
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - db_data:/var/lib/postgresql/data
 

--- a/env.example
+++ b/env.example
@@ -24,6 +24,14 @@ OLLAMA_PORT=11434
 # When false, login/logout is skipped and the admin account is used automatically
 MULTI_USER=true
 
+# PostgreSQL configuration
+POSTGRES_USER=whispad
+POSTGRES_PASSWORD=change_me
+POSTGRES_DB=whispad
+
+# Complete database URL used by the backend
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+
 # Optional: integration with a workflow agent (for example, n8n)
 # Set the URL of a webhook where saved notes will be sent
 WORKFLOW_WEBHOOK_URL=
@@ -31,3 +39,6 @@ WORKFLOW_WEBHOOK_URL=
 WORKFLOW_WEBHOOK_TOKEN=
 # Username whose notes will be sent to the webhook
 WORKFLOW_WEBHOOK_USER=
+
+# Password for the initial admin account
+ADMIN_PASSWORD=change_me

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,5 @@
 import os
+os.environ.setdefault("ADMIN_PASSWORD", "secret")
 import pytest
 from backend import app, HASHER
 from db import pool, init_db, create_user, get_user

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,5 @@
+import os
+os.environ.setdefault("ADMIN_PASSWORD", "intpass")
 from backend import app, HASHER
 from db import pool, init_db, create_user
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,7 +1,9 @@
+import os
+os.environ.setdefault("ADMIN_PASSWORD", "benchmark")
 from backend import HASHER
 
 
 def test_hash_performance(benchmark):
     benchmark(lambda: HASHER.hash('benchmark'))
-    assert benchmark.stats.stats['mean'] < 0.4
+    assert benchmark.stats.stats.mean < 0.4
 


### PR DESCRIPTION
## Summary
- remove stored `users.json`
- stop exposing database port
- load DB credentials from `.env`
- require admin password via `ADMIN_PASSWORD`
- update tests for new env vars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874bbe069d8832ebfb4fb40bc6cf856