### PR TITLE
Add provider support for mindmaps

### DIFF
--- a/app.js
+++ b/app.js
@@ -1514,7 +1514,7 @@ class NotesApp {
     }
 
     showGraphModal(topic = null) {
-        const noteText = document.getElementById('editor').innerText || '';
+        const noteText = this.getCurrentMarkdown();
         const payload = {
             note: noteText,
             provider: this.config.postprocessProvider || 'openai',
@@ -1694,7 +1694,7 @@ class NotesApp {
         output.textContent = '';
         output.classList.remove('hidden');
 
-        const noteText = document.getElementById('editor').innerText || '';
+        const noteText = this.getCurrentMarkdown();
         const provider = this.config.postprocessProvider;
         const model = this.config.postprocessModel;
         const payload = { note: noteText, messages: [{ role: 'user', content: topic }], stream: true, provider, model };
@@ -2385,6 +2385,12 @@ class NotesApp {
         }
         
         return markdown.trim();
+    }
+
+    getCurrentMarkdown() {
+        const title = document.getElementById('note-title').value.trim() || 'Untitled Note';
+        const html = document.getElementById('editor').innerHTML;
+        return this.htmlToMarkdown(html, title);
     }
 
     markdownToHtml(markdown) {
@@ -4564,7 +4570,7 @@ class NotesApp {
         const addSelected = document.getElementById('chat-add-selected').checked;
         let noteText = '';
         if (addFull) {
-            noteText = document.getElementById('editor').innerText || '';
+            noteText = this.getCurrentMarkdown();
         } else if (addSelected) {
             noteText = this.selectedText || '';
         }

--- a/backend-api.js
+++ b/backend-api.js
@@ -647,6 +647,28 @@ class BackendAPI {
             throw error;
         }
     }
+
+    async generateMindmap(note, provider, model, topic = null, host = null, port = null) {
+        try {
+            const payload = { note, provider, model };
+            if (topic) payload.topic = topic;
+            if (host) payload.host = host;
+            if (port) payload.port = port;
+            const response = await authFetch(`${this.baseUrl}/api/mindmap`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (!response.ok) {
+                const err = await response.json();
+                throw new Error(err.error || `HTTP ${response.status}`);
+            }
+            return await response.json();
+        } catch (error) {
+            console.error('Error generating mindmap:', error);
+            throw error;
+        }
+    }
 }
 
 // Instancia global del API backend

--- a/backend.py
+++ b/backend.py
@@ -15,6 +15,29 @@ from datetime import datetime
 import shutil
 from whisper_cpp_wrapper import WhisperCppWrapper
 from sensevoice_wrapper import get_sensevoice_wrapper
+from mermaid import Mermaid
+
+def extract_json(text: str):
+    """Try to extract and parse a JSON object from raw text."""
+    if not text:
+        return None
+    # Remove common code block delimiters
+    text = text.strip()
+    if text.startswith('```'):
+        text = re.sub(r'^```(?:json)?', '', text)
+        text = re.sub(r'```$', '', text)
+    # Find the first JSON object in the string
+    match = re.search(r'{.*}', text, re.DOTALL)
+    if match:
+        text = match.group(0)
+    try:
+        return json.loads(text)
+    except Exception:
+        try:
+            fixed = re.sub(r',\s*}', '}', text)
+            return json.loads(fixed)
+        except Exception:
+            return None
 import threading
 
 # ---------- Path utilities ----------
@@ -1889,8 +1912,201 @@ def html_to_markdown(html_content):
     # Limpiar espacios en blanco excesivos
     markdown = re.sub(r'\n\s*\n\s*\n', '\n\n', markdown)
     markdown = markdown.strip()
-    
+
     return markdown
+
+def json_to_mermaid(data, indent=0):
+    lines = []
+    if indent == 0:
+        lines.append('mindmap')
+    prefix = '  ' * indent
+    title = data.get('title') or data.get('topic') or 'Root'
+    lines.append(f"{prefix}{title}")
+    for child in data.get('subtopics', []):
+        lines.extend(json_to_mermaid(child, indent + 1))
+    return lines
+
+def generate_mindmap_openai(note_md, topic, model):
+    if not OPENAI_API_KEY:
+        return None, 'API key de OpenAI no configurada'
+    if not model:
+        return None, 'Model not specified'
+    system_prompt = (
+        "You create a mind map from a markdown note."
+        " Respond only with JSON using this schema:"
+        " {\"title\":string, \"subtopics\":[{\"title\":string, \"subtopics\":[]}]}."
+    )
+    if topic:
+        user_msg = f"Expand the topic '{topic}' from this note:\n\n{note_md}"
+    else:
+        user_msg = note_md
+    headers = {
+        'Authorization': f'Bearer {OPENAI_API_KEY}',
+        'Content-Type': 'application/json'
+    }
+    payload = {
+        'model': model,
+        'messages': [
+            {'role': 'system', 'content': system_prompt},
+            {'role': 'user', 'content': user_msg}
+        ]
+    }
+    resp = requests.post('https://api.openai.com/v1/chat/completions', headers=headers, json=payload)
+    if resp.status_code != 200:
+        return None, 'OpenAI error'
+    try:
+        content = resp.json()['choices'][0]['message']['content']
+        data = extract_json(content)
+        if data is None:
+            return None, 'Invalid JSON returned'
+        return data, None
+    except Exception as e:
+        return None, f'Invalid JSON returned: {str(e)}'
+
+def generate_mindmap_google(note_md, topic, model):
+    if not GOOGLE_API_KEY:
+        return None, 'API key de Google no configurada'
+    if not model:
+        return None, 'Model not specified'
+    system_prompt = (
+        "You create a mind map from a markdown note."
+        " Respond only with JSON using this schema:"
+        " {\"title\":string, \"subtopics\":[{\"title\":string, \"subtopics\":[]}]}"
+    )
+    user_msg = f"Expand the topic '{topic}' from this note:\n\n{note_md}" if topic else note_md
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={GOOGLE_API_KEY}"
+    headers = {'Content-Type': 'application/json'}
+    messages = [
+        {'role': 'system', 'content': system_prompt},
+        {'role': 'user', 'content': user_msg}
+    ]
+    payload = {
+        'contents': [
+            {
+                'role': m['role'],
+                'parts': [{'text': m['content']}]
+            } for m in messages
+        ]
+    }
+    resp = requests.post(url, headers=headers, json=payload)
+    if resp.status_code != 200:
+        return None, 'Google error'
+    try:
+        result = resp.json()
+        content = result['candidates'][0]['content']['parts'][0]['text']
+        data = extract_json(content)
+        if data is None:
+            return None, 'Invalid JSON returned'
+        return data, None
+    except Exception as e:
+        return None, f'Invalid JSON returned: {str(e)}'
+
+def generate_mindmap_openrouter(note_md, topic, model):
+    if not OPENROUTER_API_KEY:
+        return None, 'API key de OpenRouter no configurada'
+    if not model:
+        return None, 'Model not specified'
+    system_prompt = (
+        "You create a mind map from a markdown note."
+        " Respond only with JSON using this schema:"
+        " {\"title\":string, \"subtopics\":[{\"title\":string, \"subtopics\":[]}]}"
+    )
+    user_msg = f"Expand the topic '{topic}' from this note:\n\n{note_md}" if topic else note_md
+    url = 'https://openrouter.ai/api/v1/chat/completions'
+    headers = {
+        'Authorization': f'Bearer {OPENROUTER_API_KEY}',
+        'Content-Type': 'application/json',
+        'HTTP-Referer': 'https://note-transcribe-ai.local',
+        'X-Title': 'Note Transcribe AI'
+    }
+    payload = {
+        'model': model,
+        'messages': [
+            {'role': 'system', 'content': system_prompt},
+            {'role': 'user', 'content': user_msg}
+        ]
+    }
+    resp = requests.post(url, headers=headers, json=payload)
+    if resp.status_code != 200:
+        return None, 'OpenRouter error'
+    try:
+        content = resp.json()['choices'][0]['message']['content']
+        data = extract_json(content)
+        if data is None:
+            return None, 'Invalid JSON returned'
+        return data, None
+    except Exception as e:
+        return None, f'Invalid JSON returned: {str(e)}'
+
+def generate_mindmap_lmstudio(note_md, topic, model, host, port):
+    if not host or not port or not model:
+        return None, 'LM Studio host, port and model required'
+    system_prompt = (
+        "You create a mind map from a markdown note."
+        " Respond only with JSON using this schema:"
+        " {\"title\":string, \"subtopics\":[{\"title\":string, \"subtopics\":[]}]}"
+    )
+    user_msg = f"Expand the topic '{topic}' from this note:\n\n{note_md}" if topic else note_md
+    url = f"http://{host}:{port}/v1/chat/completions"
+    headers = {'Content-Type': 'application/json'}
+    payload = {
+        'model': model,
+        'messages': [
+            {'role': 'system', 'content': system_prompt},
+            {'role': 'user', 'content': user_msg}
+        ]
+    }
+    try:
+        resp = requests.post(url, headers=headers, json=payload)
+    except requests.RequestException as e:
+        return None, str(e)
+    if resp.status_code != 200:
+        return None, f'LM Studio error {resp.status_code}'
+    try:
+        content = resp.json()['choices'][0]['message']['content']
+        data = extract_json(content)
+        if data is None:
+            return None, 'Invalid JSON returned'
+        return data, None
+    except Exception as e:
+        return None, f'Invalid JSON returned: {str(e)}'
+
+def generate_mindmap_ollama(note_md, topic, model, host, port):
+    if not host or not port or not model:
+        return None, 'Ollama host, port and model required'
+    system_prompt = (
+        "You create a mind map from a markdown note."
+        " Respond only with JSON using this schema:"
+        " {\"title\":string, \"subtopics\":[{\"title\":string, \"subtopics\":[]}]}"
+    )
+    user_msg = f"Expand the topic '{topic}' from this note:\n\n{note_md}" if topic else note_md
+    url = f"http://{host}:{port}/api/chat"
+    headers = {'Content-Type': 'application/json'}
+    payload = {
+        'model': model,
+        'messages': [
+            {'role': 'system', 'content': system_prompt},
+            {'role': 'user', 'content': user_msg}
+        ]
+    }
+    try:
+        resp = requests.post(url, headers=headers, json=payload)
+    except requests.RequestException as e:
+        return None, str(e)
+    if resp.status_code != 200:
+        return None, f'Ollama error {resp.status_code}'
+    try:
+        result = resp.json()
+        if isinstance(result, dict) and 'message' in result and result['message']:
+            content = result['message'].get('content', '')
+        else:
+            content = result.get('choices', [{}])[0].get('message', {}).get('content', '')
+        data = extract_json(content)
+        if data is None:
+            return None, 'Invalid JSON returned'
+        return data, None
+    except Exception as e:
+        return None, f'Invalid JSON returned: {str(e)}'
 
 @app.route('/api/check-apis', methods=['GET'])
 def check_apis():
@@ -1902,6 +2118,51 @@ def check_apis():
         'openrouter': bool(OPENROUTER_API_KEY)
     }
     return jsonify(apis_status)
+
+
+@app.route('/api/mindmap', methods=['POST'])
+def generate_mindmap():
+    """Generate a mermaid mindmap from note markdown."""
+    try:
+        username = get_current_username()
+        if not username:
+            return jsonify({"error": "Unauthorized"}), 401
+
+        data = request.get_json() or {}
+        note = data.get('note', '')
+        topic = data.get('topic')
+        provider = data.get('provider', 'openai')
+        model = data.get('model', 'gpt-3.5-turbo')
+        host = data.get('host')
+        port = data.get('port')
+
+        if provider == 'openai':
+            tree, err = generate_mindmap_openai(note, topic, model)
+        elif provider == 'google':
+            tree, err = generate_mindmap_google(note, topic, model)
+        elif provider == 'openrouter':
+            tree, err = generate_mindmap_openrouter(note, topic, model)
+        elif provider == 'lmstudio':
+            host = host or LMSTUDIO_HOST
+            port = port or LMSTUDIO_PORT
+            tree, err = generate_mindmap_lmstudio(note, topic, model, host, port)
+        elif provider == 'ollama':
+            host = host or OLLAMA_HOST
+            port = port or OLLAMA_PORT
+            tree, err = generate_mindmap_ollama(note, topic, model, host, port)
+        else:
+            return jsonify({"error": "Provider not supported"}), 400
+
+        if err:
+            return jsonify({"error": err}), 500
+
+        mm_lines = json_to_mermaid(tree)
+        mm_script = "\n".join(mm_lines)
+        svg = Mermaid(mm_script).svg_response.text
+
+        return jsonify({"svg": svg, "tree": tree})
+    except Exception as e:
+        return jsonify({"error": f"Error interno: {str(e)}"}), 500
 
 
 @app.route('/api/app-config', methods=['GET'])

--- a/backend.py
+++ b/backend.py
@@ -34,14 +34,16 @@ def extract_json(text: str):
     try:
         return json.loads(text)
     except Exception:
+        pass
+    fixed = re.sub(r",\s*([}\]])", r"\1", text)
+    fixed = fixed.replace("'", '"')
+    try:
+        return json.loads(fixed)
+    except Exception:
         try:
-            fixed = re.sub(r',\s*([}\]])', r'\1', text)
-            return json.loads(fixed)
+            return ast.literal_eval(text)
         except Exception:
-            try:
-                return ast.literal_eval(text)
-            except Exception:
-                return None
+            return None
 import threading
 
 # ---------- Path utilities ----------

--- a/index.html
+++ b/index.html
@@ -290,6 +290,12 @@
                 <button class="btn btn--outline btn--sm" id="next-graph-btn" title="Next graph">
                     <i class="fas fa-arrow-right"></i>
                 </button>
+                <button class="btn btn--outline btn--sm" id="zoom-in-graph-btn" title="Zoom in">
+                    <i class="fas fa-search-plus"></i>
+                </button>
+                <button class="btn btn--outline btn--sm" id="zoom-out-graph-btn" title="Zoom out">
+                    <i class="fas fa-search-minus"></i>
+                </button>
                 <button class="btn btn--outline btn--sm" id="download-graph-btn">Download</button>
                 <button class="btn btn--outline btn--sm" id="close-graph-modal">Close</button>
             </div>

--- a/index.html
+++ b/index.html
@@ -157,6 +157,9 @@
                     <button class="btn btn--outline btn--sm" id="chat-sidebar-toggle" title="Chat assistant">
                         <i class="fas fa-comments"></i>&nbsp;Chat
                     </button>
+                    <button class="btn btn--outline btn--sm" id="graph-btn" title="Graph view">
+                        <i class="fas fa-project-diagram"></i>&nbsp;Graph
+                    </button>
                 </div>
             </div>
                 
@@ -273,6 +276,17 @@
         <div class="processing-content">
             <div class="spinner"></div>
             <p id="processing-text">Processing...</p>
+        </div>
+    </div>
+
+    <!-- Graph modal -->
+    <div class="modal" id="graph-modal">
+        <div class="modal-content modal-content--wide">
+            <div class="graph-container" id="graph-container"></div>
+            <div class="modal-actions">
+                <button class="btn btn--outline btn--sm" id="download-graph-btn">Download</button>
+                <button class="btn btn--outline btn--sm" id="close-graph-modal">Close</button>
+            </div>
         </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -284,6 +284,12 @@
         <div class="modal-content modal-content--wide">
             <div class="graph-container" id="graph-container"></div>
             <div class="modal-actions">
+                <button class="btn btn--outline btn--sm" id="prev-graph-btn" title="Previous graph">
+                    <i class="fas fa-arrow-left"></i>
+                </button>
+                <button class="btn btn--outline btn--sm" id="next-graph-btn" title="Next graph">
+                    <i class="fas fa-arrow-right"></i>
+                </button>
                 <button class="btn btn--outline btn--sm" id="download-graph-btn">Download</button>
                 <button class="btn btn--outline btn--sm" id="close-graph-modal">Close</button>
             </div>

--- a/index.html
+++ b/index.html
@@ -283,6 +283,14 @@
     <div class="modal" id="graph-modal">
         <div class="modal-content modal-content--wide">
             <div class="graph-container" id="graph-container"></div>
+            <div class="graph-text-output hidden" id="graph-text-output"></div>
+            <div class="checkbox-group">
+                <label class="checkbox-label">
+                    <input type="checkbox" id="graph-text-toggle">
+                    <span class="checkmark"></span>
+                    Text exploration
+                </label>
+            </div>
             <div class="modal-actions">
                 <button class="btn btn--outline btn--sm" id="prev-graph-btn" title="Previous graph">
                     <i class="fas fa-arrow-left"></i>

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ psycopg-pool
 argon2-cffi
 pytest
 pytest-benchmark
+mermaid-py

--- a/style.css
+++ b/style.css
@@ -2584,12 +2584,22 @@ select.form-control {
 
 /* Graph modal */
 .graph-container {
-    overflow: auto;
+    overflow: hidden;
     max-height: 80vh;
     margin-bottom: var(--space-16);
+    position: relative;
 }
 
-.graph-container svg {
+#graph-pan-zoom {
+    transform-origin: 0 0;
+    cursor: grab;
+}
+
+#graph-pan-zoom.grabbing {
+    cursor: grabbing;
+}
+
+#graph-pan-zoom svg {
     width: 100%;
     height: auto;
 }

--- a/style.css
+++ b/style.css
@@ -2585,7 +2585,7 @@ select.form-control {
 /* Graph modal */
 .graph-container {
     overflow: hidden;
-    max-height: 80vh;
+    max-height: 90vh;
     margin-bottom: var(--space-16);
     position: relative;
 }
@@ -2614,4 +2614,9 @@ select.form-control {
     margin-bottom: var(--space-16);
     white-space: pre-wrap;
     color: var(--color-text);
+}
+
+/* Larger modal for graph view */
+#graph-modal .modal-content--wide {
+    max-width: 1000px;
 }

--- a/style.css
+++ b/style.css
@@ -2581,3 +2581,15 @@ select.form-control {
 .chat-input button {
     margin-left: var(--space-8);
 }
+
+/* Graph modal */
+.graph-container {
+    overflow: auto;
+    max-height: 80vh;
+    margin-bottom: var(--space-16);
+}
+
+.graph-container svg {
+    width: 100%;
+    height: auto;
+}

--- a/style.css
+++ b/style.css
@@ -2603,3 +2603,15 @@ select.form-control {
     width: 100%;
     height: auto;
 }
+
+.graph-text-output {
+    max-height: 40vh;
+    overflow-y: auto;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-12);
+    margin-bottom: var(--space-16);
+    white-space: pre-wrap;
+    color: var(--color-text);
+}


### PR DESCRIPTION
## Summary
- extend frontend mindmap requests with host/port when using LM Studio or Ollama
- allow backend mindmap endpoint to use any post-processing provider
- implement helper functions for Google, OpenRouter, LM Studio and Ollama
- add download button to mindmap modal for exporting the graph

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: DATABASE_URL environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_687596df1538832e8cd657ee767ff9cf