### PR TITLE
Separate login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ WhisPad is designed to persist your data between container restarts, updates, an
 - **Default Admin**: Username `admin`, password set via `ADMIN_PASSWORD`
 - **User Configuration**: Admins can create users and assign different transcription/postprocessing providers
 - **Per-User Folders**: Each user's notes are isolated in their own folder under `saved_notes/`
-- **Single User Mode**: Set `MULTI_USER=false` in `.env` or the compose file to skip the login screen and always use the admin account
+- **Single User Mode**: Set `MULTI_USER=false` in `.env` or the compose file to automatically sign in with the admin account and bypass the login page
 
 ### Initial Setup
 On first start the backend creates the `admin` user using the password from `ADMIN_PASSWORD`.

--- a/app.js
+++ b/app.js
@@ -4323,12 +4323,7 @@ function initApp() {
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
-    const loginScreen = document.getElementById('login-screen');
     const appContent = document.getElementById('app-content');
-    const loginBtn = document.getElementById('login-submit');
-    const usernameInput = document.getElementById('login-username');
-    const passwordInput = document.getElementById('login-password');
-    const togglePasswordBtn = document.getElementById('toggle-password');
     const currentUserBtn = document.getElementById('current-user-btn');
     const logoutBtn = document.getElementById('logout-btn');
 
@@ -4407,7 +4402,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             currentUserBtn.classList.remove('hidden');
             logoutBtn.classList.remove('hidden');
             document.getElementById('user-btn').classList.remove('hidden');
-            loginScreen.classList.add('hidden');
             appContent.classList.remove('hidden');
             initApp();
             return true;
@@ -4419,7 +4413,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     if (multiUser) {
-        restoreSession();
+        const restored = await restoreSession();
+        if (!restored) {
+            window.location.href = 'login.html';
+            return;
+        }
     } else {
         currentUser = 'admin';
         isAdmin = true;
@@ -4437,85 +4435,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         currentUserBtn.classList.add('hidden');
         logoutBtn.classList.add('hidden');
         document.getElementById('user-btn').classList.add('hidden');
-        loginScreen.classList.add('hidden');
         appContent.classList.remove('hidden');
         initApp();
-    }
-
-    async function attemptLogin() {
-        const username = usernameInput.value.trim();
-        const password = passwordInput.value;
-        try {
-            const resp = await fetch('/api/login', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ username, password })
-            });
-            if (resp.ok) {
-                const data = await resp.json();
-                authToken = data.token;
-                currentUser = username;
-                allowedTranscriptionProviders = data.transcription_providers || [];
-                allowedPostprocessProviders = data.postprocess_providers || [];
-                isAdmin = data.is_admin;
-                
-                // Clear any old localStorage data from previous sessions
-                localStorage.removeItem('notes-app-data'); // Remove old global key
-                
-                await loadDefaultProviderConfig();
-                if (!isAdmin) {
-                    const cfgKey = `notes-app-config-${currentUser}`;
-                    let cfg = {};
-                    const savedCfg = localStorage.getItem(cfgKey);
-                    if (savedCfg) cfg = JSON.parse(savedCfg);
-                    if (defaultProviderConfig.lmstudio_host) {
-                        cfg.lmstudioHost = defaultProviderConfig.lmstudio_host;
-                        cfg.lmstudioPort = defaultProviderConfig.lmstudio_port;
-                    }
-                    if (defaultProviderConfig.ollama_host) {
-                        cfg.ollamaHost = defaultProviderConfig.ollama_host;
-                        cfg.ollamaPort = defaultProviderConfig.ollama_port;
-                    }
-                    localStorage.setItem(cfgKey, JSON.stringify(cfg));
-                }
-                if (isAdmin) {
-                    document.querySelectorAll('.admin-only').forEach(el => {
-                        if (!el.classList.contains('tab-content')) {
-                            el.style.display = '';
-                        }
-                    });
-                } else {
-                    document.querySelectorAll('.admin-only').forEach(el => {
-                        if (!el.classList.contains('tab-content')) {
-                            el.style.display = 'none';
-                        }
-                    });
-                }
-                localStorage.setItem('notes-app-session', JSON.stringify({ token: authToken }));
-                currentUserBtn.textContent = username;
-                currentUserBtn.classList.remove('hidden');
-                logoutBtn.classList.remove('hidden');
-                document.getElementById('user-btn').classList.remove('hidden');
-                loginScreen.classList.add('hidden');
-                appContent.classList.remove('hidden');
-                initApp();
-            } else {
-                alert('Login failed');
-            }
-        } catch (e) {
-            alert('Login error');
-        }
-    }
-
-    loginBtn.addEventListener('click', attemptLogin);
-    usernameInput.addEventListener('keydown', e => { if (e.key === 'Enter') attemptLogin(); });
-    passwordInput.addEventListener('keydown', e => { if (e.key === 'Enter') attemptLogin(); });
-    if (togglePasswordBtn) {
-        togglePasswordBtn.addEventListener('click', () => {
-            const isHidden = passwordInput.getAttribute('type') === 'password';
-            passwordInput.setAttribute('type', isHidden ? 'text' : 'password');
-            togglePasswordBtn.innerHTML = isHidden ? '<i class="fas fa-eye-slash"></i>' : '<i class="fas fa-eye"></i>';
-        });
     }
 
     logoutBtn.addEventListener('click', async () => {
@@ -4539,8 +4460,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         allowedTranscriptionProviders = [];
         allowedPostprocessProviders = [];
         isAdmin = false;
-        usernameInput.value = '';
-        passwordInput.value = '';
         currentUserBtn.classList.add('hidden');
         logoutBtn.classList.add('hidden');
         document.getElementById('user-btn').classList.add('hidden');
@@ -4569,11 +4488,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         const noteTitle = document.getElementById('note-title');
         if (noteTitle) noteTitle.value = '';
         document.querySelector('.editor-container')?.classList.add('hidden');
-        loginScreen.classList.remove('hidden');
-        appContent.classList.add('hidden');
-
-        // Force a full page reload to ensure all state is cleared
-        window.location.reload(true);
+        if (multiUser) {
+            window.location.href = 'login.html';
+        } else {
+            // Force a full page reload to ensure all state is cleared
+            window.location.reload(true);
+        }
     });
 
     async function refreshUserList() {

--- a/index.html
+++ b/index.html
@@ -9,25 +9,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
 <body>
-    <!-- Login screen -->
-    <div class="login-screen" id="login-screen">
-        <div class="login-box">
-            <img src="logos/logo.png" alt="WhisPad Logo" class="login-logo">
-            <h3>Login</h3>
-            <div class="modal-body">
-                <input type="text" class="form-control" id="login-username" placeholder="Username">
-                <div class="password-wrapper" style="margin-top:10px;">
-                    <input type="password" class="form-control" id="login-password" placeholder="Password">
-                    <button type="button" class="toggle-password" id="toggle-password" aria-label="Show password">
-                        <i class="fas fa-eye"></i>
-                    </button>
-                </div>
-            </div>
-            <div class="modal-actions">
-                <button type="button" class="btn btn--primary" id="login-submit">Login</button>
-            </div>
-        </div>
-    </div>
 
     <!-- User management modal -->
     <div class="modal" id="user-modal">

--- a/login.html
+++ b/login.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>WhisPad Login</title>
+    <link rel="icon" type="image/png" href="logos/logo.png">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+</head>
+<body>
+    <div class="login-screen" id="login-screen">
+        <div class="login-box">
+            <img src="logos/logo.png" alt="WhisPad Logo" class="login-logo">
+            <h3>Login</h3>
+            <div class="modal-body">
+                <input type="text" class="form-control" id="login-username" placeholder="Username">
+                <div class="password-wrapper" style="margin-top:10px;">
+                    <input type="password" class="form-control" id="login-password" placeholder="Password">
+                    <button type="button" class="toggle-password" id="toggle-password" aria-label="Show password">
+                        <i class="fas fa-eye"></i>
+                    </button>
+                </div>
+            </div>
+            <div class="modal-actions">
+                <button type="button" class="btn btn--primary" id="login-submit">Login</button>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+    <script src="login.js"></script>
+</body>
+</html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,71 @@
+document.addEventListener('DOMContentLoaded', async () => {
+    const loginBtn = document.getElementById('login-submit');
+    const usernameInput = document.getElementById('login-username');
+    const passwordInput = document.getElementById('login-password');
+    const togglePasswordBtn = document.getElementById('toggle-password');
+    let multiUser = true;
+
+    try {
+        const resp = await fetch('/api/app-config');
+        if (resp.ok) {
+            const cfg = await resp.json();
+            multiUser = cfg.multi_user;
+        }
+    } catch (err) {
+        console.error('Error fetching app config:', err);
+    }
+
+    if (!multiUser) {
+        window.location.href = 'index.html';
+        return;
+    }
+
+    async function restoreSession() {
+        const saved = localStorage.getItem('notes-app-session');
+        if (!saved) return false;
+        try {
+            const session = JSON.parse(saved);
+            const resp = await fetch('/api/session-info', { headers: { 'Authorization': session.token } });
+            if (resp.ok) {
+                window.location.href = 'index.html';
+                return true;
+            }
+        } catch {}
+        localStorage.removeItem('notes-app-session');
+        return false;
+    }
+
+    await restoreSession();
+
+    async function attemptLogin() {
+        const username = usernameInput.value.trim();
+        const password = passwordInput.value;
+        try {
+            const resp = await fetch('/api/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, password })
+            });
+            if (resp.ok) {
+                const data = await resp.json();
+                localStorage.setItem('notes-app-session', JSON.stringify({ token: data.token }));
+                window.location.href = 'index.html';
+            } else {
+                alert('Login failed');
+            }
+        } catch {
+            alert('Login error');
+        }
+    }
+
+    loginBtn.addEventListener('click', attemptLogin);
+    usernameInput.addEventListener('keydown', e => { if (e.key === 'Enter') attemptLogin(); });
+    passwordInput.addEventListener('keydown', e => { if (e.key === 'Enter') attemptLogin(); });
+    if (togglePasswordBtn) {
+        togglePasswordBtn.addEventListener('click', () => {
+            const isHidden = passwordInput.getAttribute('type') === 'password';
+            passwordInput.setAttribute('type', isHidden ? 'text' : 'password');
+            togglePasswordBtn.innerHTML = isHidden ? '<i class="fas fa-eye-slash"></i>' : '<i class="fas fa-eye"></i>';
+        });
+    }
+});


### PR DESCRIPTION
## Summary
- move login screen into new `login.html`
- add `login.js` to handle login independently
- clean up `index.html` and update `app.js` to redirect to `login.html`
- document auto sign-in when `MULTI_USER` is disabled

## Testing
- `PYTHONPATH=. pytest -q tests/test_auth.py tests/test_integration.py` *(fails: DATABASE_URL environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68760564524c832eaf5e3f884e5e2fd0