### PR TITLE
Fix chat sidebar width resizing and checkbox visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,8 +223,16 @@
         <div class="chat-sidebar" id="chat-sidebar">
             <div class="chat-header">
                 <div class="checkbox-group">
-                    <label><input type="checkbox" id="chat-add-full"> Add full note</label>
-                    <label><input type="checkbox" id="chat-add-selected"> Add selected text</label>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="chat-add-full">
+                        <span class="checkmark"></span>
+                        Add full note
+                    </label>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="chat-add-selected">
+                        <span class="checkmark"></span>
+                        Add selected text
+                    </label>
                 </div>
             </div>
             <div class="chat-messages" id="chat-messages"></div>

--- a/style.css
+++ b/style.css
@@ -2513,6 +2513,9 @@ select.form-control {
 /* Chat sidebar */
 .chat-sidebar {
     width: 320px;
+    min-width: 220px;
+    resize: horizontal;
+    overflow: auto;
     background-color: var(--color-surface);
     border-left: 1px solid var(--color-border);
     display: none;


### PR DESCRIPTION
## Summary
- allow the chat sidebar to be resized horizontally
- style chat sidebar checkboxes using existing custom styles so they are always visible

## Testing
- `pytest -q` *(fails: DATABASE_URL environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68761bec1c28832eb099800d0e524d52