### PR TITLE
Reposition buttons in interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,14 +60,11 @@
             <h1 class="app-title">WhisPad</h1>
         </div>
         <div class="header-actions">
-            <button class="btn btn--outline btn--sm" id="download-all-btn" title="Download all notes">
-                <i class="fas fa-file-zipper"></i>&nbsp;Download All
-            </button>
-            <button class="btn btn--outline btn--sm" id="restore-btn" title="Restore notes from files">
-                <i class="fas fa-upload"></i>&nbsp;Restore
-            </button>
             <button class="btn btn--outline btn--sm admin-only" id="upload-models-btn" title="Manage whisper.cpp models">
                 <i class="fas fa-download"></i>&nbsp;Models
+            </button>
+            <button class="btn btn--outline btn--sm" id="config-btn" title="Configure providers">
+                <i class="fas fa-cog"></i>&nbsp;Config
             </button>
             <button class="btn btn--outline btn--sm hidden" id="user-btn" title="User management">
                 <i class="fas fa-users"></i>&nbsp;Users
@@ -83,10 +80,19 @@
     <div class="app-container">
         <!-- Sidebar -->
         <div class="sidebar">
+
             <div class="sidebar-header">
                 <h2>My Notes</h2>
                 <button class="btn btn--primary btn--sm" id="new-note-btn">
                     <i class="fas fa-plus"></i>&nbsp;New Note
+                </button>
+            </div>
+            <div class="notes-actions">
+                <button class="btn btn--outline btn--sm" id="download-all-btn" title="Download all notes">
+                    <i class="fas fa-file-zipper"></i>&nbsp;Download All
+                </button>
+                <button class="btn btn--outline btn--sm" id="restore-btn" title="Restore notes from files">
+                    <i class="fas fa-upload"></i>&nbsp;Restore
                 </button>
             </div>
 
@@ -123,24 +129,23 @@
                         <span class="status-text">Ready to record</span>
                         <div class="recording-indicator" id="recording-indicator"></div>
                     </div>
-                    <button class="btn btn--outline btn--sm" id="config-btn" title="Configure providers">
-                        <i class="fas fa-cog"></i>&nbsp;Config
-                    </button>
-                    <button class="btn btn--outline btn--sm" id="styles-config-btn" title="Configure enhancement styles">
-                        <i class="fas fa-palette"></i>&nbsp;Styles
-                    </button>
-                    <button class="btn btn--outline btn--sm" id="translation-settings-btn" title="Translation settings">
-                        <i class="fas fa-language"></i>&nbsp;Translation
-                    </button>
-                    <button class="btn btn--outline btn--sm" id="prompt-sidebar-toggle" title="Custom prompt">
-                        <i class="fas fa-terminal"></i>&nbsp;Prompt
-                    </button>
-                    <button class="btn btn--outline btn--sm" id="chat-sidebar-toggle" title="Chat assistant">
-                        <i class="fas fa-comments"></i>&nbsp;Chat
-                    </button>
-                    <button class="btn btn--outline btn--sm" id="graph-btn" title="Graph view">
-                        <i class="fas fa-project-diagram"></i>&nbsp;Graph
-                    </button>
+                    <div class="transcription-grid">
+                        <button class="btn btn--outline btn--sm" id="styles-config-btn" title="Configure enhancement styles">
+                            <i class="fas fa-palette"></i>&nbsp;Styles
+                        </button>
+                        <button class="btn btn--outline btn--sm" id="translation-settings-btn" title="Translation settings">
+                            <i class="fas fa-language"></i>&nbsp;Translation
+                        </button>
+                        <button class="btn btn--outline btn--sm" id="prompt-sidebar-toggle" title="Custom prompt">
+                            <i class="fas fa-terminal"></i>&nbsp;Prompt
+                        </button>
+                        <button class="btn btn--outline btn--sm" id="chat-sidebar-toggle" title="Chat assistant">
+                            <i class="fas fa-comments"></i>&nbsp;Chat
+                        </button>
+                        <button class="btn btn--outline btn--sm" id="graph-btn" title="Graph view">
+                            <i class="fas fa-project-diagram"></i>&nbsp;Graph
+                        </button>
+                    </div>
                 </div>
             </div>
                 

--- a/style.css
+++ b/style.css
@@ -864,6 +864,12 @@ select.form-control {
     color: var(--color-text);
 }
 
+.notes-actions {
+    padding: var(--space-16);
+    display: flex;
+    gap: var(--space-8);
+}
+
 .search-container {
     padding: var(--space-16);
     position: relative;
@@ -975,6 +981,40 @@ select.form-control {
     display: flex;
     align-items: center;
     gap: var(--space-16);
+}
+
+.transcription-grid {
+    display: grid;
+    grid-template-columns: repeat(3, auto);
+    grid-template-rows: repeat(2, auto);
+    column-gap: var(--space-16);
+    row-gap: var(--space-8);
+}
+
+#styles-config-btn {
+    grid-column: 1;
+    grid-row: 1;
+}
+
+#translation-settings-btn {
+    grid-column: 1;
+    grid-row: 2;
+}
+
+#prompt-sidebar-toggle {
+    grid-column: 2;
+    grid-row: 1;
+}
+
+#chat-sidebar-toggle {
+    grid-column: 2;
+    grid-row: 2;
+}
+
+#graph-btn {
+    grid-column: 3;
+    grid-row: 1 / span 2;
+    align-self: center;
 }
 
 .recording-status {


### PR DESCRIPTION
## Summary
- relocate config button from toolbar to the header
- place Download All and Restore buttons inside the notes sidebar
- add styles for new notes actions section
- organize Styles/Translation/Prompt/Chat/Graph buttons in a three-column grid

## Testing
- `pip install plotly pandas flask flask-cors requests python-dotenv pydub librosa soundfile mermaid-py argon2-cffi psycopg_pool psycopg[binary]`
- `pytest -q` *(fails: DATABASE_URL environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68761aa08cac832ea669d239f7e6cfb0