### PR TITLE
Implement audio file upload and management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ Thumbs.db
 
 # Archivos de notas guardadas (datos de usuario)
 saved_notes/
+saved_audios/
 temp_notes/
 uploads/
 recordings/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ WhisPad is a transcription and note management tool designed so anyone can turn 
 - Compatible with multiple providers: OpenAI, SenseVoice and local whisper.cpp. No model is bundled, but you can download tiny, small, base, medium or large versions from the interface.
 - **NEW: SenseVoice Integration** - Advanced multilingual speech recognition with emotion detection and audio event recognition for 50+ languages.
 - Download or upload local (.bin) whisper.cpp models directly from the interface.
+- Upload audio files which are automatically transcribed and stored alongside your notes.
 - Export all notes in a ZIP file with one click.
 - Mobile-friendly interface.
 - User login with per-user note folders and admin management tools.

--- a/index.html
+++ b/index.html
@@ -695,6 +695,17 @@
         </div>
     </div>
 
+    <!-- Audio files modal -->
+    <div class="modal" id="audio-modal">
+        <div class="modal-content">
+            <h3>Audio Files</h3>
+            <ul id="audio-file-list"></ul>
+            <div class="modal-actions">
+                <button class="btn btn--outline" id="close-audio-modal">Close</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Download/Upload models modal -->
     <div class="modal" id="upload-model-modal">
         <div class="modal-content">

--- a/style.css
+++ b/style.css
@@ -2667,3 +2667,17 @@ select.form-control {
 #graph-modal .modal-content--wide {
     max-width: 1000px;
 }
+
+/* Audio files list */
+#audio-file-list {
+    list-style: none;
+    padding: 0;
+    margin-bottom: var(--space-16);
+}
+
+#audio-file-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--space-8);
+}


### PR DESCRIPTION
## Summary
- allow saving audio files in `saved_audios` directory
- list, download and delete audio files via new API endpoints
- show audio files in a new modal
- style audio file listing
- handle audio upload from the UI

## Testing
- `pytest -q` *(fails: DATABASE_URL environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_687621803e98832eb75d12f4e5c2811c