### PR TITLE
Add contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,8 @@ SenseVoice is based on FunASR and provides enterprise-grade speech recognition c
 
 This project was developed with the help of AI tools including **Perplexity Labs**, **OpenAI Codex**, and **Claude 4**. Local transcription models run thanks to [whisper.cpp](https://github.com/ggml-org/whisper.cpp) (a copy is bundled here for easier installation).
 
+## Contributors
+
+- **@Drakonis96** - Main idea and core coding.
+- **@laweschan** - Contributed fresh insights and tested the application.
+


### PR DESCRIPTION
## Summary
- add a new Contributors section at the end of README listing Drakonis96 and @laweschan
- fix handle and description per review feedback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests' and 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687623226ab8832e8dab0b6889a0019c