### PR TITLE
Fix sidebar buttons layout and equal button sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,18 +82,20 @@
         <div class="sidebar">
 
             <div class="sidebar-header">
-                <h2>My Notes</h2>
-                <button class="btn btn--primary btn--sm" id="new-note-btn">
-                    <i class="fas fa-plus"></i>&nbsp;New Note
-                </button>
-            </div>
-            <div class="notes-actions">
-                <button class="btn btn--outline btn--sm" id="download-all-btn" title="Download all notes">
-                    <i class="fas fa-file-zipper"></i>&nbsp;Download All
-                </button>
-                <button class="btn btn--outline btn--sm" id="restore-btn" title="Restore notes from files">
-                    <i class="fas fa-upload"></i>&nbsp;Restore
-                </button>
+                <div class="header-top">
+                    <h2>My Notes</h2>
+                    <button class="btn btn--primary btn--sm" id="new-note-btn">
+                        <i class="fas fa-plus"></i>&nbsp;New Note
+                    </button>
+                </div>
+                <div class="notes-actions">
+                    <button class="btn btn--outline btn--sm" id="download-all-btn" title="Download all notes">
+                        <i class="fas fa-file-zipper"></i>&nbsp;Download All
+                    </button>
+                    <button class="btn btn--outline btn--sm" id="restore-btn" title="Restore notes from files">
+                        <i class="fas fa-upload"></i>&nbsp;Restore
+                    </button>
+                </div>
             </div>
 
             <!-- Header actions moved here on mobile -->

--- a/style.css
+++ b/style.css
@@ -851,11 +851,11 @@ select.form-control {
 }
 
 .sidebar-header {
-    padding: var(--space-20) var(--space-16);
+    padding: var(--space-20) var(--space-16) var(--space-12);
     border-bottom: 1px solid var(--color-border);
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    flex-direction: column;
+    gap: var(--space-8);
 }
 
 .sidebar-header h2 {
@@ -864,8 +864,13 @@ select.form-control {
     color: var(--color-text);
 }
 
+.header-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
 .notes-actions {
-    padding: var(--space-16);
     display: flex;
     gap: var(--space-8);
 }
@@ -985,10 +990,14 @@ select.form-control {
 
 .transcription-grid {
     display: grid;
-    grid-template-columns: repeat(3, auto);
+    grid-template-columns: repeat(3, 1fr);
     grid-template-rows: repeat(2, auto);
     column-gap: var(--space-16);
     row-gap: var(--space-8);
+}
+
+.transcription-grid button {
+    width: 100%;
 }
 
 #styles-config-btn {


### PR DESCRIPTION
## Summary
- move restore/download buttons inside sidebar header
- style header as column layout with spacing
- adjust button grid to equal width

## Testing
- `pytest -q` *(fails: couldn't get a connection after 30 sec)*

------
https://chatgpt.com/codex/tasks/task_e_687626b54aac832e98b5ad229185153e