### PR TITLE
Fix chat sidebar resizing

### DIFF
--- a/app.js
+++ b/app.js
@@ -575,6 +575,39 @@ class NotesApp {
             });
         }
 
+        const chatResizer = document.getElementById('chat-resizer');
+        if (chatResizer && chatSidebar) {
+            let startX = 0;
+            let startWidth = 0;
+
+            const doDrag = (e) => {
+                const clientX = e.touches ? e.touches[0].clientX : e.clientX;
+                const newWidth = Math.max(startWidth + (startX - clientX), 220);
+                chatSidebar.style.width = `${newWidth}px`;
+                e.preventDefault();
+            };
+
+            const stopDrag = () => {
+                document.removeEventListener('mousemove', doDrag);
+                document.removeEventListener('touchmove', doDrag);
+                document.removeEventListener('mouseup', stopDrag);
+                document.removeEventListener('touchend', stopDrag);
+            };
+
+            const startDrag = (e) => {
+                startX = e.touches ? e.touches[0].clientX : e.clientX;
+                startWidth = chatSidebar.offsetWidth;
+                document.addEventListener('mousemove', doDrag);
+                document.addEventListener('touchmove', doDrag);
+                document.addEventListener('mouseup', stopDrag);
+                document.addEventListener('touchend', stopDrag);
+                e.preventDefault();
+            };
+
+            chatResizer.addEventListener('mousedown', startDrag);
+            chatResizer.addEventListener('touchstart', startDrag);
+        }
+
         // Graph button
         const graphBtn = document.getElementById('graph-btn');
         const graphClose = document.getElementById('close-graph-modal');

--- a/index.html
+++ b/index.html
@@ -229,6 +229,7 @@
             <button class="btn btn--primary btn--sm" id="apply-custom-prompt" style="margin-top: 10px;">Apply</button>
         </div>
         <div class="chat-sidebar" id="chat-sidebar">
+            <div class="chat-resizer" id="chat-resizer"></div>
             <div class="chat-header">
                 <div class="checkbox-group">
                     <label class="checkbox-label">

--- a/style.css
+++ b/style.css
@@ -2564,10 +2564,21 @@ select.form-control {
     border-left: 1px solid var(--color-border);
     display: none;
     flex-direction: column;
+    position: relative;
 }
 
 .chat-sidebar.active {
     display: flex;
+}
+
+.chat-resizer {
+    width: 5px;
+    cursor: col-resize;
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    background-color: var(--color-border);
 }
 
 .chat-header {


### PR DESCRIPTION
## Summary
- make chat sidebar resizable with a drag handle
- style the handle and position it within the sidebar
- implement JS logic to drag the sidebar width

## Testing
- `pip install flask flask-cors requests python-dotenv psycopg-binary psycopg-pool argon2-cffi pytest-benchmark` *(passed)*
- `pip install mermaid-py` *(passed)*
- `pytest -q` *(fails: DATABASE_URL environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_687627fd34c8832e9f503cb0550c3d02