### PR TITLE
Add audio playback dropdown

### DIFF
--- a/app.js
+++ b/app.js
@@ -360,6 +360,22 @@ class NotesApp {
                 this.hideAudioModal();
             });
         }
+
+        const playBtn = document.getElementById('play-audio-btn');
+        if (playBtn) {
+            playBtn.addEventListener('click', () => {
+                this.playSelectedAudio();
+            });
+        }
+
+        const refreshBtn = document.getElementById('refresh-audio-btn');
+        if (refreshBtn) {
+            refreshBtn.addEventListener('click', () => {
+                if (this.currentNote) {
+                    this.loadAudioDropdown(this.currentNote.id);
+                }
+            });
+        }
         
         // Editor
         const editor = document.getElementById('editor');
@@ -1317,6 +1333,7 @@ class NotesApp {
         this.clearAIHistory();
 
         this.updateEditorVisibility();
+        this.loadAudioDropdown(this.currentNote.id);
     }
     
     updateNoteSelection() {
@@ -3210,6 +3227,35 @@ class NotesApp {
             li.appendChild(btnWrap);
             list.appendChild(li);
         });
+    }
+
+    async loadAudioDropdown(noteId) {
+        const select = document.getElementById('audio-select');
+        if (!select) return;
+        select.innerHTML = '';
+        if (!noteId) return;
+        try {
+            const response = await authFetch(`/api/list-audios?note_id=${noteId}`);
+            if (!response.ok) return;
+            const data = await response.json();
+            (data.audios || []).forEach(fname => {
+                const opt = document.createElement('option');
+                opt.value = fname;
+                opt.textContent = fname;
+                select.appendChild(opt);
+            });
+        } catch (err) {
+            console.error('Error loading audios', err);
+        }
+    }
+
+    playSelectedAudio() {
+        const select = document.getElementById('audio-select');
+        const player = document.getElementById('note-audio-player');
+        if (!select || !player || !select.value) return;
+        player.src = `/api/get-audio?filename=${encodeURIComponent(select.value)}`;
+        player.style.display = 'block';
+        player.play().catch(err => console.error('Audio play error', err));
     }
     
     // Mejora con IA

--- a/backend.py
+++ b/backend.py
@@ -2640,6 +2640,24 @@ def download_audio():
     except Exception as e:
         return jsonify({"error": f"Error al descargar audio: {str(e)}"}), 500
 
+@app.route('/api/get-audio', methods=['GET'])
+def get_audio():
+    """Serve an audio file for playback"""
+    try:
+        username = get_current_username()
+        if not username:
+            return jsonify({"error": "Unauthorized"}), 401
+        filename = request.args.get('filename')
+        if not filename:
+            return jsonify({"error": "filename requerido"}), 400
+        audio_dir = os.path.join(os.getcwd(), 'saved_audios', username)
+        filepath = os.path.join(audio_dir, sanitize_filename(filename))
+        if not is_path_within_directory(audio_dir, filepath) or not os.path.exists(filepath):
+            return jsonify({"error": "File not found"}), 404
+        return send_file(filepath, as_attachment=False, download_name=filename)
+    except Exception as e:
+        return jsonify({"error": f"Error al obtener audio: {str(e)}"}), 500
+
 @app.route('/api/delete-audio', methods=['POST'])
 def delete_audio():
     """Delete an audio file"""

--- a/index.html
+++ b/index.html
@@ -188,6 +188,16 @@
                             <i class="fas fa-trash"></i>&nbsp;Delete
                         </button>
                     </div>
+                    <div class="audio-row">
+                        <select id="audio-select" class="form-control audio-select"></select>
+                        <button class="btn btn--outline btn--sm" id="refresh-audio-btn" title="Refresh audio list">
+                            <i class="fas fa-sync"></i>
+                        </button>
+                        <button class="btn btn--outline btn--sm" id="play-audio-btn" title="Play audio">
+                            <i class="fas fa-play"></i>
+                        </button>
+                    </div>
+                    <audio id="note-audio-player" class="audio-player" controls style="display:none;margin-top:4px;"></audio>
                 </div>
 
                 <div class="note-tags" id="note-tags"></div>

--- a/style.css
+++ b/style.css
@@ -1152,6 +1152,22 @@ select.form-control {
     gap: var(--space-8);
 }
 
+.audio-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-8);
+    margin-top: var(--space-8);
+}
+
+.audio-select {
+    flex: 1;
+}
+
+.audio-player {
+    width: 100%;
+    margin-top: var(--space-8);
+}
+
 .formatting-toolbar {
     padding: var(--space-12) var(--space-20);
     border-bottom: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary
- serve audio without download header via `/api/get-audio`
- add audio dropdown and playback controls below note title
- style new audio selector elements
- load and play selected audio files from the browser

## Testing
- `pytest -q` *(fails: DATABASE_URL environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68762c7b31ac832eb680a442fc2fe15c