### PR TITLE
Fix audio note dropdown layout and reset

### DIFF
--- a/app.js
+++ b/app.js
@@ -1333,6 +1333,16 @@ class NotesApp {
         this.clearAIHistory();
 
         this.updateEditorVisibility();
+        const audioSelect = document.getElementById('audio-select');
+        if (audioSelect) {
+            audioSelect.value = '';
+        }
+        const player = document.getElementById('note-audio-player');
+        if (player) {
+            player.pause();
+            player.removeAttribute('src');
+            player.style.display = 'none';
+        }
         this.loadAudioDropdown(this.currentNote.id);
     }
     

--- a/style.css
+++ b/style.css
@@ -1130,6 +1130,7 @@ select.form-control {
     display: flex;
     align-items: center;
     gap: var(--space-16);
+    flex-wrap: wrap;
 }
 
 .note-title {
@@ -1160,12 +1161,14 @@ select.form-control {
 }
 
 .audio-select {
-    flex: 1;
+    width: 200px;
+    flex: 0 0 auto;
 }
 
 .audio-player {
     width: 100%;
     margin-top: var(--space-8);
+    flex: 0 0 100%;
 }
 
 .formatting-toolbar {


### PR DESCRIPTION
## Summary
- keep the editor header from shifting when playing audio
- give the audio dropdown a fixed width
- reset audio controls when switching notes

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: couldn't get DB connection)*

------
https://chatgpt.com/codex/tasks/task_e_68763451f4ec832ea0114121635d876a