### PR TITLE
Add persistent saved_audios dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,8 +83,8 @@ RUN mkdir -p /var/log/nginx && \
     chmod 666 /var/log/nginx/error.log
 
 # Crear directorio para notas guardadas con permisos apropiados
-RUN mkdir -p /app/saved_notes && \
-    chmod 777 /app/saved_notes
+RUN mkdir -p /app/saved_notes /app/saved_audios && \
+    chmod 777 /app/saved_notes /app/saved_audios
 
 # Hacer ejecutable el script de inicio
 RUN chmod +x start.sh

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ WhisPad is designed to persist your data between container restarts, updates, an
 
 ### Persistent Data
 - **Notes**: Stored in `./saved_notes/` (mounted to `/app/saved_notes` in container)
+- **Audio Files**: Stored in `./saved_audios/` (mounted to `/app/saved_audios` in container)
 - **Users**: Stored in PostgreSQL (`whispad` database)
 - **Provider Config**: Stored in PostgreSQL database (no external file needed)
 - **Models**: Stored in `./whisper-cpp-models/` (mounted to `/app/whisper-cpp-models` in container)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     volumes:
       - ./logs:/var/log/nginx
       - ./saved_notes:/app/saved_notes
+      - ./saved_audios:/app/saved_audios
       - ./whisper-cpp-models:/app/whisper-cpp-models
     restart: unless-stopped
 

--- a/start.sh
+++ b/start.sh
@@ -20,8 +20,8 @@ if [ ! -f /etc/nginx/certs/selfsigned.crt ]; then
 fi
 
 # Crear y configurar directorios persistentes
-mkdir -p /app/saved_notes
-chmod 777 /app/saved_notes
+mkdir -p /app/saved_notes /app/saved_audios
+chmod 777 /app/saved_notes /app/saved_audios
 
 # Note: Configuration is now stored in PostgreSQL database
 # users.json and server_config.json will be migrated automatically if they exist


### PR DESCRIPTION
## Summary
- create `/app/saved_audios` in Dockerfile just like `/app/saved_notes`
- make `saved_audios` directory on container startup
- mount `./saved_audios` in compose file
- document audio storage in README

## Testing
- `pytest -q tests/test_auth.py::test_login_ok -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_687636480920832e97dbe3de61f7a569