### PR TITLE
Enhance audio file modal controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -719,6 +719,18 @@
         </div>
     </div>
 
+    <!-- Delete audio confirmation modal -->
+    <div class="modal" id="delete-audio-modal">
+        <div class="modal-content">
+            <h3>Confirm deletion</h3>
+            <p>Are you sure you want to delete this file? This action cannot be undone.</p>
+            <div class="modal-actions">
+                <button class="btn btn--outline" id="cancel-delete-audio">Cancel</button>
+                <button class="btn btn--primary" id="confirm-delete-audio">Delete</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Download/Upload models modal -->
     <div class="modal" id="upload-model-modal">
         <div class="modal-content">

--- a/style.css
+++ b/style.css
@@ -2720,3 +2720,18 @@ select.form-control {
     align-items: center;
     margin-bottom: var(--space-8);
 }
+
+# Buttons wrapper for audio files
+# ensures spacing between download and delete icons
+# see renderAudioFiles in app.js
+#
+# Example markup:
+#   <span class="file-actions">
+#       <button>...</button>
+#       <button>...</button>
+#   </span>
+
+.file-actions {
+    display: flex;
+    gap: var(--space-8);
+}


### PR DESCRIPTION
## Summary
- add icon-only download/delete buttons for audio files
- provide spacing for file action buttons
- confirm audio deletion with new modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mermaid')*

------
https://chatgpt.com/codex/tasks/task_e_68763ae1e7a4832eb62a32f2b3f8d315