### PR TITLE
Forward auth header in nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -34,6 +34,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Authorization $http_authorization;
         
         # Timeouts para requests largos (transcripción y subida de modelos)
         proxy_connect_timeout 300s;
@@ -57,6 +58,7 @@ server {
         proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Authorization $http_authorization;
     }
     
     # Logs


### PR DESCRIPTION
## Summary
- forward `Authorization` header to backend
- keep health endpoint consistent

## Testing
- `pytest tests/test_auth.py tests/test_integration.py tests/test_performance.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6877480534ec832ea2c81f071155660a