### PR TITLE
Handle missing login page

### DIFF
--- a/login.js
+++ b/login.js
@@ -3,6 +3,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     const usernameInput = document.getElementById('login-username');
     const passwordInput = document.getElementById('login-password');
     const togglePasswordBtn = document.getElementById('toggle-password');
+
+    // If the expected elements are missing, the wrong page was likely served.
+    // Avoid throwing errors by exiting early and logging a warning so the user
+    // can adjust the proxy configuration.
+    if (!loginBtn || !usernameInput || !passwordInput) {
+        console.warn('Login elements missing. Ensure login.html is served.');
+        return;
+    }
     let multiUser = true;
 
     try {


### PR DESCRIPTION
## Summary
- add warning and early return in login.js if login elements are missing

## Testing
- `pip install flask requests`
- `pip install flask-cors`
- `pip install mermaid-py`
- `pip install argon2-cffi`
- `pytest -q` *(fails: PoolTimeout - couldn't get connection)*

------
https://chatgpt.com/codex/tasks/task_e_68775b23a588832e98d84efe9a11b155