### PR TITLE
Persist note tags across devices

### DIFF
--- a/app.js
+++ b/app.js
@@ -825,6 +825,7 @@ class NotesApp {
                 throw new Error(`HTTP ${response.status}`);
             }
             const data = await response.json();
+            note.tags = (data.tags || []).map(t => t.toLowerCase());
             let markdown = data.content || '';
 
             // Remove metadata section

--- a/backend.py
+++ b/backend.py
@@ -3129,15 +3129,17 @@ def get_note():
         basename = os.path.basename(filepath)
 
         meta_path = f"{filepath}.meta"
+        tags = []
         if os.path.exists(meta_path):
             try:
                 with open(meta_path, 'r', encoding='utf-8') as meta_file:
                     meta = json.load(meta_file)
                 note_id = meta.get('id', note_id)
+                tags = [t.lower() for t in meta.get('tags', []) if isinstance(t, str)]
             except Exception:
                 pass
 
-        return jsonify({"filename": basename, "id": note_id, "content": content})
+        return jsonify({"filename": basename, "id": note_id, "content": content, "tags": tags})
     except Exception as e:
         return jsonify({"error": f"Error al leer nota: {str(e)}"}), 500
 


### PR DESCRIPTION
## Summary
- return tags in `/api/get-note` response
- update frontend to store tags from API

## Testing
- `pytest -q` *(fails: DATABASE_URL environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_687770e2a598832e9f89a9b4589922e8