### PR TITLE
Improve mobile AI tools layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -4885,7 +4885,9 @@ class NotesApp {
         sections.forEach(sec => {
             const toggle = sec.querySelector('.collapse-toggle');
             if (toggle) {
-                toggle.addEventListener('click', () => {
+                toggle.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
                     if (window.innerWidth <= 768) {
                         sec.classList.toggle('collapsed');
                     }
@@ -4896,10 +4898,16 @@ class NotesApp {
 
     hideMobileFab() {
         const mobileFab = document.getElementById('mobile-record-fab');
+        const toolsFab = document.getElementById('mobile-tools-fab');
+        const toolsMenu = document.getElementById('mobile-tools-menu');
         if (mobileFab) mobileFab.classList.add('hidden');
+        if (toolsFab) toolsFab.classList.add('hidden');
+        if (toolsMenu) toolsMenu.classList.add('hidden');
     }
 
     showMobileFab() {
+        const toolsMenu = document.getElementById('mobile-tools-menu');
+        if (toolsMenu) toolsMenu.classList.add('hidden');
         this.updateMobileFabVisibility();
     }
 

--- a/app.js
+++ b/app.js
@@ -5028,6 +5028,7 @@ function initApp() {
 document.addEventListener('DOMContentLoaded', async () => {
     const appContent = document.getElementById('app-content');
     const currentUserBtn = document.getElementById('current-user-btn');
+    const currentUserText = document.getElementById('current-user-text');
     const logoutBtn = document.getElementById('logout-btn');
 
     try {
@@ -5101,7 +5102,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     }
                 });
             }
-            currentUserBtn.textContent = currentUser;
+            if (currentUserText) currentUserText.textContent = currentUser;
             currentUserBtn.classList.remove('hidden');
             logoutBtn.classList.remove('hidden');
             document.getElementById('user-btn').classList.remove('hidden');

--- a/app.js
+++ b/app.js
@@ -206,6 +206,7 @@ class NotesApp {
         this.setupSidebarResponsive();
         this.setupMobileHeaderActions();
         this.updateMobileFabVisibility();
+        this.setupCollapsibleSections();
 
         // Migrate existing notes without ID
         await this.migrateExistingNotes();
@@ -332,6 +333,24 @@ class NotesApp {
                 this.toggleRecording();
             };
             mobileFab.addEventListener('click', handleMobileFab);
+        }
+
+        const toolsFab = document.getElementById('mobile-tools-fab');
+        const toolsMenu = document.getElementById('mobile-tools-menu');
+        if (toolsFab && toolsMenu) {
+            toolsFab.addEventListener('click', () => {
+                toolsMenu.classList.toggle('hidden');
+            });
+            toolsMenu.querySelectorAll('.mobile-tool-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const target = btn.dataset.target;
+                    if (target) {
+                        const el = document.getElementById(target);
+                        if (el) el.click();
+                    }
+                    toolsMenu.classList.add('hidden');
+                });
+            });
         }
         
         // Botones de IA - Se configurarán dinámicamente con updateAIButtons()
@@ -4838,10 +4857,41 @@ class NotesApp {
 
     updateMobileFabVisibility() {
         const mobileFab = document.getElementById('mobile-record-fab');
-        if (!mobileFab) return;
+        const toolsFab = document.getElementById('mobile-tools-fab');
+        const toolsMenu = document.getElementById('mobile-tools-menu');
 
-        const shouldShow = this.config.showMobileRecordButton !== false && window.innerWidth <= 768;
-        mobileFab.classList.toggle('hidden', !shouldShow);
+        const isMobile = window.innerWidth <= 768;
+        if (mobileFab) {
+            const shouldShowRecord = this.config.showMobileRecordButton !== false && isMobile;
+            mobileFab.classList.toggle('hidden', !shouldShowRecord);
+        }
+        if (toolsFab) {
+            toolsFab.classList.toggle('hidden', !isMobile);
+            if (!isMobile && toolsMenu) {
+                toolsMenu.classList.add('hidden');
+            }
+        }
+    }
+
+    setupCollapsibleSections() {
+        const sections = document.querySelectorAll('.toolbar-section.collapsible');
+        const handleResize = () => {
+            if (window.innerWidth > 768) {
+                sections.forEach(sec => sec.classList.remove('collapsed'));
+            }
+        };
+        handleResize();
+        window.addEventListener('resize', handleResize);
+        sections.forEach(sec => {
+            const toggle = sec.querySelector('.collapse-toggle');
+            if (toggle) {
+                toggle.addEventListener('click', () => {
+                    if (window.innerWidth <= 768) {
+                        sec.classList.toggle('collapsed');
+                    }
+                });
+            }
+        });
     }
 
     hideMobileFab() {

--- a/app.js
+++ b/app.js
@@ -4874,7 +4874,7 @@ class NotesApp {
     }
 
     setupCollapsibleSections() {
-        const sections = document.querySelectorAll('.toolbar-section.collapsible');
+        const sections = document.querySelectorAll('.collapsible');
         const handleResize = () => {
             if (window.innerWidth > 768) {
                 sections.forEach(sec => sec.classList.remove('collapsed'));

--- a/index.html
+++ b/index.html
@@ -203,15 +203,15 @@
                             <button class="btn btn--outline btn--sm" id="delete-btn">
                                 <i class="fas fa-trash"></i>&nbsp;<span id="delete-text">Delete</span>
                             </button>
-                        </div>
-                        <div class="audio-row">
-                            <button class="btn btn--outline btn--sm" id="refresh-audio-btn" title="Refresh audio list">
-                                <i class="fas fa-sync"></i>
-                            </button>
-                            <select id="audio-select" class="form-control audio-select"></select>
-                            <button class="btn btn--outline btn--sm" id="play-audio-btn" title="Play audio">
-                                <i class="fas fa-play"></i>
-                            </button>
+                            <div class="audio-row">
+                                <button class="btn btn--outline btn--sm" id="refresh-audio-btn" title="Refresh audio list">
+                                    <i class="fas fa-sync"></i>
+                                </button>
+                                <select id="audio-select" class="form-control audio-select"></select>
+                                <button class="btn btn--outline btn--sm" id="play-audio-btn" title="Play audio">
+                                    <i class="fas fa-play"></i>
+                                </button>
+                            </div>
                         </div>
                         <audio id="note-audio-player" class="audio-player" controls style="display:none;margin-top:4px;"></audio>
                     </div>

--- a/index.html
+++ b/index.html
@@ -199,10 +199,10 @@
                         </button>
                     </div>
                     <div class="audio-row">
-                        <select id="audio-select" class="form-control audio-select"></select>
                         <button class="btn btn--outline btn--sm" id="refresh-audio-btn" title="Refresh audio list">
                             <i class="fas fa-sync"></i>
                         </button>
+                        <select id="audio-select" class="form-control audio-select"></select>
                         <button class="btn btn--outline btn--sm" id="play-audio-btn" title="Play audio">
                             <i class="fas fa-play"></i>
                         </button>

--- a/index.html
+++ b/index.html
@@ -61,16 +61,16 @@
         </div>
         <div class="header-actions">
             <button class="btn btn--outline btn--sm admin-only" id="upload-models-btn" title="Manage whisper.cpp models">
-                <i class="fas fa-download"></i>&nbsp;Models
+                <i class="fas fa-download"></i>&nbsp;<span class="header-btn-text">Models</span>
             </button>
             <button class="btn btn--outline btn--sm" id="config-btn" title="Configure providers">
-                <i class="fas fa-cog"></i>&nbsp;Config
+                <i class="fas fa-cog"></i>&nbsp;<span class="header-btn-text">Config</span>
             </button>
             <button class="btn btn--outline btn--sm hidden" id="user-btn" title="User management">
-                <i class="fas fa-users"></i>&nbsp;Users
+                <i class="fas fa-users"></i>&nbsp;<span class="header-btn-text">Users</span>
             </button>
-            <button class="btn btn--outline btn--sm hidden" id="current-user-btn"></button>
-            <button class="btn btn--error btn--sm hidden" id="logout-btn">Logout</button>
+            <button class="btn btn--outline btn--sm hidden" id="current-user-btn"><span class="header-btn-text" id="current-user-text"></span></button>
+            <button class="btn btn--error btn--sm hidden" id="logout-btn"><span class="header-btn-text">Logout</span></button>
             <button class="hamburger-menu" id="hamburger-menu" aria-label="Show/Hide notes menu">
                 <span></span><span></span><span></span>
             </button>

--- a/index.html
+++ b/index.html
@@ -117,14 +117,19 @@
         <div class="main-content">
             <!-- Top toolbar -->
             <div class="toolbar">
-                <div class="toolbar-section">
-                <h3>Transcription Tools</h3>
-                <div class="transcription-controls">
+                <div class="toolbar-section collapsible" id="transcription-section">
+                    <div class="section-header">
+                        <h3>Transcription Tools</h3>
+                        <button class="collapse-toggle" aria-label="Toggle transcription tools">
+                            <i class="fas fa-chevron-up"></i>
+                        </button>
+                    </div>
+                    <div class="transcription-controls section-content">
                     <button class="btn btn--primary" id="record-btn">
                         <i class="fas fa-microphone" id="record-icon"></i>&nbsp;<span id="record-text">Record</span>
                     </button>
                     <button class="btn btn--secondary btn--sm" id="upload-audio-btn" title="Upload audio file">
-                        <i class="fas fa-file-audio"></i>&nbsp;Upload Audio
+                        <i class="fas fa-file-audio"></i>&nbsp;<span id="upload-audio-text">Upload Audio</span>
                     </button>
                     <input type="file" id="upload-audio-input" accept=".mp3,.wav" style="display:none">
                     <div class="recording-status" id="recording-status">
@@ -151,12 +156,17 @@
                             <i class="fas fa-folder"></i>&nbsp;Files
                         </button>
                     </div>
+                    </div>
                 </div>
-            </div>
-                
-                <div class="toolbar-section">
-                    <h3>AI Enhancement</h3>
-                    <div class="ai-controls" id="ai-controls">
+
+                <div class="toolbar-section collapsible" id="ai-section">
+                    <div class="section-header">
+                        <h3>AI Enhancement</h3>
+                        <button class="collapse-toggle" aria-label="Toggle AI enhancement">
+                            <i class="fas fa-chevron-up"></i>
+                        </button>
+                    </div>
+                    <div class="ai-controls section-content" id="ai-controls">
                         <button class="btn btn--secondary btn--sm ai-btn" data-action="clarity" title="Improve text clarity">
                             <span class="ai-icon">✨</span>&nbsp;Clarity
                         </button>
@@ -179,13 +189,13 @@
                     <input type="text" class="form-control note-title" id="note-title" placeholder="Note title...">
                     <div class="editor-actions">
                         <button class="btn btn--outline btn--sm" id="save-btn">
-                            <i class="fas fa-save"></i>&nbsp;Save
+                            <i class="fas fa-save"></i>&nbsp;<span id="save-text">Save</span>
                         </button>
                         <button class="btn btn--outline btn--sm" id="download-btn">
-                            <i class="fas fa-download"></i>&nbsp;Download
+                            <i class="fas fa-download"></i>&nbsp;<span id="download-text">Download</span>
                         </button>
                         <button class="btn btn--outline btn--sm" id="delete-btn">
-                            <i class="fas fa-trash"></i>&nbsp;Delete
+                            <i class="fas fa-trash"></i>&nbsp;<span id="delete-text">Delete</span>
                         </button>
                     </div>
                     <div class="audio-row">
@@ -777,6 +787,29 @@
     <button id="mobile-record-fab" class="mobile-fab" aria-label="Record">
         <i class="fas fa-microphone"></i>
     </button>
+    <button id="mobile-tools-fab" class="mobile-fab" aria-label="Tools">
+        <i class="fas fa-tools"></i>
+    </button>
+    <div id="mobile-tools-menu" class="mobile-tools-menu hidden">
+        <button class="mobile-tool-btn" data-target="styles-config-btn" aria-label="Styles">
+            <i class="fas fa-palette"></i>
+        </button>
+        <button class="mobile-tool-btn" data-target="translation-settings-btn" aria-label="Translation">
+            <i class="fas fa-language"></i>
+        </button>
+        <button class="mobile-tool-btn" data-target="prompt-sidebar-toggle" aria-label="Prompt">
+            <i class="fas fa-terminal"></i>
+        </button>
+        <button class="mobile-tool-btn" data-target="chat-sidebar-toggle" aria-label="Chat">
+            <i class="fas fa-comments"></i>
+        </button>
+        <button class="mobile-tool-btn" data-target="graph-btn" aria-label="Graph">
+            <i class="fas fa-project-diagram"></i>
+        </button>
+        <button class="mobile-tool-btn" data-target="files-btn" aria-label="Files">
+            <i class="fas fa-folder"></i>
+        </button>
+    </div>
     </div> <!-- end app-content -->
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
     <script src="backend-api.js"></script>

--- a/index.html
+++ b/index.html
@@ -185,29 +185,36 @@
             
             <!-- Editing area -->
             <div class="editor-container hidden">
-                <div class="editor-header">
-                    <input type="text" class="form-control note-title" id="note-title" placeholder="Note title...">
-                    <div class="editor-actions">
-                        <button class="btn btn--outline btn--sm" id="save-btn">
-                            <i class="fas fa-save"></i>&nbsp;<span id="save-text">Save</span>
-                        </button>
-                        <button class="btn btn--outline btn--sm" id="download-btn">
-                            <i class="fas fa-download"></i>&nbsp;<span id="download-text">Download</span>
-                        </button>
-                        <button class="btn btn--outline btn--sm" id="delete-btn">
-                            <i class="fas fa-trash"></i>&nbsp;<span id="delete-text">Delete</span>
+                <div class="editor-header collapsible" id="note-header">
+                    <div class="section-header">
+                        <input type="text" class="form-control note-title" id="note-title" placeholder="Note title...">
+                        <button class="collapse-toggle" aria-label="Toggle note tools">
+                            <i class="fas fa-chevron-up"></i>
                         </button>
                     </div>
-                    <div class="audio-row">
-                        <button class="btn btn--outline btn--sm" id="refresh-audio-btn" title="Refresh audio list">
-                            <i class="fas fa-sync"></i>
-                        </button>
-                        <select id="audio-select" class="form-control audio-select"></select>
-                        <button class="btn btn--outline btn--sm" id="play-audio-btn" title="Play audio">
-                            <i class="fas fa-play"></i>
-                        </button>
+                    <div class="section-content">
+                        <div class="editor-actions">
+                            <button class="btn btn--outline btn--sm" id="save-btn">
+                                <i class="fas fa-save"></i>&nbsp;<span id="save-text">Save</span>
+                            </button>
+                            <button class="btn btn--outline btn--sm" id="download-btn">
+                                <i class="fas fa-download"></i>&nbsp;<span id="download-text">Download</span>
+                            </button>
+                            <button class="btn btn--outline btn--sm" id="delete-btn">
+                                <i class="fas fa-trash"></i>&nbsp;<span id="delete-text">Delete</span>
+                            </button>
+                        </div>
+                        <div class="audio-row">
+                            <button class="btn btn--outline btn--sm" id="refresh-audio-btn" title="Refresh audio list">
+                                <i class="fas fa-sync"></i>
+                            </button>
+                            <select id="audio-select" class="form-control audio-select"></select>
+                            <button class="btn btn--outline btn--sm" id="play-audio-btn" title="Play audio">
+                                <i class="fas fa-play"></i>
+                            </button>
+                        </div>
+                        <audio id="note-audio-player" class="audio-player" controls style="display:none;margin-top:4px;"></audio>
                     </div>
-                    <audio id="note-audio-player" class="audio-player" controls style="display:none;margin-top:4px;"></audio>
                 </div>
 
                 <div class="note-tags" id="note-tags"></div>

--- a/style.css
+++ b/style.css
@@ -48,7 +48,7 @@
     display: none;
   }
   .mobile-header-actions {
-    display: flex;
+    display: grid;
   }
 }
 
@@ -384,10 +384,20 @@ body {
 /* Container for header buttons when on mobile */
 .mobile-header-actions {
   display: none;
-  flex-direction: column;
-  gap: var(--space-12);
-  padding: var(--space-16);
+  grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
+  gap: var(--space-8);
+  padding: var(--space-8) var(--space-16);
   border-bottom: 1px solid var(--color-border);
+}
+
+.mobile-header-actions .btn {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+}
+
+.mobile-header-actions .header-btn-text {
+  display: none;
 }
 
 *,

--- a/style.css
+++ b/style.css
@@ -991,7 +991,7 @@ select.form-control {
     display: none;
 }
 
-.toolbar-section.collapsed .collapse-toggle i {
+.collapsible.collapsed .collapse-toggle i {
     transform: rotate(180deg);
 }
 
@@ -1159,9 +1159,8 @@ select.form-control {
     padding: var(--space-16) var(--space-20);
     border-bottom: 1px solid var(--color-border);
     display: flex;
-    align-items: center;
-    gap: var(--space-16);
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: var(--space-12);
 }
 
 .note-title {
@@ -1641,7 +1640,7 @@ select.form-control {
         display: inline-flex;
     }
 
-    .toolbar-section.collapsible.collapsed .section-content {
+    .collapsible.collapsed .section-content {
         display: none;
     }
 }

--- a/style.css
+++ b/style.css
@@ -989,6 +989,7 @@ select.form-control {
     font-size: 16px;
     padding: 0;
     display: none;
+    cursor: pointer;
 }
 
 .collapsible.collapsed .collapse-toggle i {
@@ -1181,18 +1182,22 @@ select.form-control {
 .editor-actions {
     display: flex;
     gap: var(--space-8);
+    justify-content: center;
+    flex-wrap: wrap;
+    align-items: center;
 }
 
 .audio-row {
     display: flex;
     align-items: center;
     gap: var(--space-8);
-    margin-top: var(--space-8);
+    margin-top: 0;
 }
 
 .audio-select {
     width: 200px;
     flex: 0 0 auto;
+    height: 40px;
 }
 
 .audio-player {
@@ -1630,10 +1635,12 @@ select.form-control {
     .audio-row {
         justify-content: center;
         width: 100%;
+        margin-top: var(--space-8);
     }
     #audio-select {
         flex: 1 1 auto;
         width: auto;
+        height: 40px;
     }
 
     .collapse-toggle {
@@ -2473,8 +2480,9 @@ select.form-control {
     display: none;
 }
 
-#mobile-tools-menu.hidden {
-    display: none;
+
+#mobile-tools-menu:not(.hidden) {
+    display: flex;
 }
 
 #mobile-tools-menu button {
@@ -2492,9 +2500,6 @@ select.form-control {
 
 @media (max-width: 768px) {
     #mobile-tools-fab {
-        display: flex;
-    }
-    #mobile-tools-menu {
         display: flex;
     }
 }

--- a/style.css
+++ b/style.css
@@ -2475,10 +2475,14 @@ select.form-control {
     bottom: calc(env(safe-area-inset-bottom, 0px) + 80px);
     left: calc(50% + 72px);
     transform: translateX(-50%);
-    display: flex;
     flex-direction: column;
     gap: 8px;
     z-index: 1100;
+    display: none;
+}
+
+#mobile-tools-menu.hidden {
+    display: none;
 }
 
 #mobile-tools-menu button {
@@ -2496,6 +2500,9 @@ select.form-control {
 
 @media (max-width: 768px) {
     #mobile-tools-fab {
+        display: flex;
+    }
+    #mobile-tools-menu {
         display: flex;
     }
 }

--- a/style.css
+++ b/style.css
@@ -1629,19 +1629,12 @@ select.form-control {
 
     /* Center audio dropdown with buttons on sides */
     .audio-row {
-        display: grid;
-        grid-template-columns: auto 1fr auto;
-        align-items: center;
-    }
-    #audio-select {
-        grid-column: 2;
+        justify-content: center;
         width: 100%;
     }
-    #refresh-audio-btn {
-        grid-column: 1;
-    }
-    #play-audio-btn {
-        grid-column: 3;
+    #audio-select {
+        flex: 1 1 auto;
+        width: auto;
     }
 
     .collapse-toggle {

--- a/style.css
+++ b/style.css
@@ -975,6 +975,26 @@ select.form-control {
     gap: var(--space-12);
 }
 
+.section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-8);
+}
+
+.collapse-toggle {
+    background: none;
+    border: none;
+    color: var(--color-text);
+    font-size: 16px;
+    padding: 0;
+    display: none;
+}
+
+.toolbar-section.collapsed .collapse-toggle i {
+    transform: rotate(180deg);
+}
+
 .toolbar-section h3 {
     margin: 0;
     font-size: var(--font-size-md);
@@ -998,6 +1018,17 @@ select.form-control {
 
 .transcription-grid button {
     width: 100%;
+}
+
+@media (max-width: 768px) {
+    .transcription-grid {
+        display: none;
+    }
+    #record-text,
+    #upload-audio-text,
+    .recording-status .status-text {
+        display: none;
+    }
 }
 
 #styles-config-btn {
@@ -1572,7 +1603,11 @@ select.form-control {
     }
     
     .ai-controls {
-        justify-content: center;
+        justify-content: flex-start;
+        width: 100%;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
     }
     
     .editor-header {
@@ -1583,6 +1618,38 @@ select.form-control {
     
     .editor-actions {
         justify-content: center;
+    }
+
+    /* Hide action button text on mobile */
+    #save-text,
+    #download-text,
+    #delete-text {
+        display: none;
+    }
+
+    /* Center audio dropdown with buttons on sides */
+    .audio-row {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+    }
+    #audio-select {
+        grid-column: 2;
+        width: 100%;
+    }
+    #refresh-audio-btn {
+        grid-column: 1;
+    }
+    #play-audio-btn {
+        grid-column: 3;
+    }
+
+    .collapse-toggle {
+        display: inline-flex;
+    }
+
+    .toolbar-section.collapsible.collapsed .section-content {
+        display: none;
     }
 }
 
@@ -2378,6 +2445,57 @@ select.form-control {
 
 @media (max-width: 768px) {
     #mobile-record-fab {
+        display: flex;
+    }
+}
+
+/* Floating tools button and menu on mobile */
+#mobile-tools-fab {
+    position: fixed;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
+    left: calc(50% + 72px);
+    transform: translateX(-50%);
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background-color: var(--color-primary);
+    color: #fff;
+    border: none;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    z-index: 1100;
+    pointer-events: auto;
+    touch-action: manipulation;
+}
+
+#mobile-tools-menu {
+    position: fixed;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 80px);
+    left: calc(50% + 72px);
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    z-index: 1100;
+}
+
+#mobile-tools-menu button {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background-color: var(--color-primary);
+    color: #fff;
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
+}
+
+@media (max-width: 768px) {
+    #mobile-tools-fab {
         display: flex;
     }
 }


### PR DESCRIPTION
## Summary
- keep mobile AI buttons in one row with scrolling
- add floating tools button for Styles/Translation/Prompt/Chat/Graph/Files
- allow collapsing toolbars on small screens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: 'requests' and 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68777cab3344832e820e9fa3abefaffb