### PR TITLE
Add diagram type selector and API

### DIFF
--- a/app.js
+++ b/app.js
@@ -682,6 +682,7 @@ class NotesApp {
         const graphZoomIn = document.getElementById('zoom-in-graph-btn');
         const graphZoomOut = document.getElementById('zoom-out-graph-btn');
         const graphTypeSelect = document.getElementById('graph-type-select');
+        const regenerateGraphBtn = document.getElementById('regenerate-graph-btn');
         if (graphBtn) {
             graphBtn.addEventListener('click', () => { this.showGraphModal(); });
         }
@@ -706,6 +707,11 @@ class NotesApp {
         if (graphTypeSelect) {
             graphTypeSelect.addEventListener('change', e => {
                 this.graphType = e.target.value;
+            });
+        }
+        if (regenerateGraphBtn) {
+            regenerateGraphBtn.addEventListener('click', () => {
+                this.showGraphModal();
             });
         }
 
@@ -1763,7 +1769,7 @@ class NotesApp {
             )
             .then(data => {
                 this.mindMapTree = null;
-                handleSvg({ svg: data.svg, tree: null });
+                handleSvg({ svg: data.svg, tree: data.tree || null });
             })
             .catch(err => this.showNotification(err.message || 'Diagram request failed', 'error'))
             .finally(() => this.hideProcessingOverlay());

--- a/backend-api.js
+++ b/backend-api.js
@@ -669,6 +669,27 @@ class BackendAPI {
             throw error;
         }
     }
+
+    async generateDiagram(note, provider, model, type, host = null, port = null) {
+        try {
+            const payload = { note, provider, model, type };
+            if (host) payload.host = host;
+            if (port) payload.port = port;
+            const response = await authFetch(`${this.baseUrl}/api/diagram`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (!response.ok) {
+                const err = await response.json();
+                throw new Error(err.error || `HTTP ${response.status}`);
+            }
+            return await response.json();
+        } catch (error) {
+            console.error('Error generating diagram:', error);
+            throw error;
+        }
+    }
 }
 
 // Instancia global del API backend

--- a/index.html
+++ b/index.html
@@ -328,6 +328,7 @@
                     <option value="user journey">User journey</option>
                     <option value="pie chart">Pie chart</option>
                 </select>
+                <button class="btn btn--outline btn--sm" id="regenerate-graph-btn" title="Regenerate graph">↻</button>
             </div>
             <div class="modal-actions">
                 <button class="btn btn--outline btn--sm" id="prev-graph-btn" title="Previous graph">

--- a/index.html
+++ b/index.html
@@ -318,6 +318,17 @@
                     Text exploration
                 </label>
             </div>
+            <div class="graph-controls">
+                <select class="form-control" id="graph-type-select">
+                    <option value="mindmap" selected>Mindmap</option>
+                    <option value="timeline">Timeline</option>
+                    <option value="treemap">Treemap</option>
+                    <option value="radar">Radar</option>
+                    <option value="sequence">Sequence</option>
+                    <option value="user journey">User journey</option>
+                    <option value="pie chart">Pie chart</option>
+                </select>
+            </div>
             <div class="modal-actions">
                 <button class="btn btn--outline btn--sm" id="prev-graph-btn" title="Previous graph">
                     <i class="fas fa-arrow-left"></i>

--- a/style.css
+++ b/style.css
@@ -2802,7 +2802,7 @@ select.form-control {
 
 /* Graph modal */
 .graph-container {
-    overflow: hidden;
+    overflow: auto;
     max-height: 90vh;
     margin-bottom: var(--space-16);
     position: relative;
@@ -2820,6 +2820,11 @@ select.form-control {
 #graph-pan-zoom svg {
     width: 100%;
     height: auto;
+}
+
+/* Ensure graph text is visible in all themes */
+#graph-container svg text {
+    fill: var(--color-text);
 }
 
 .graph-text-output {

--- a/style.css
+++ b/style.css
@@ -2839,6 +2839,17 @@ select.form-control {
     max-width: 1000px;
 }
 
+/* Smaller dropdown for graph type */
+#graph-type-select {
+    width: 150px;
+    font-size: var(--font-size-sm);
+    padding: var(--space-4) var(--space-8);
+}
+
+#regenerate-graph-btn {
+    margin-left: var(--space-8);
+}
+
 /* Audio files list */
 #audio-file-list {
     list-style: none;


### PR DESCRIPTION
## Summary
- add chart type dropdown with several new options
- persist selected type and use it when generating graphs
- backend endpoint `/api/diagram` generates Mermaid diagrams for all supported providers
- JS backend API now has `generateDiagram`

## Testing
- `pytest -q` *(fails: `DATABASE_URL` not set)*

------
https://chatgpt.com/codex/tasks/task_e_6877b31fb6c4832e9b544c016cc33b78