### PR TITLE
Align note toolbar with title

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,12 +188,7 @@
                 <div class="editor-header collapsible" id="note-header">
                     <div class="section-header">
                         <input type="text" class="form-control note-title" id="note-title" placeholder="Note title...">
-                        <button class="collapse-toggle" aria-label="Toggle note tools">
-                            <i class="fas fa-chevron-up"></i>
-                        </button>
-                    </div>
-                    <div class="section-content">
-                        <div class="editor-actions">
+                        <div class="editor-actions section-content">
                             <button class="btn btn--outline btn--sm" id="save-btn">
                                 <i class="fas fa-save"></i>&nbsp;<span id="save-text">Save</span>
                             </button>
@@ -213,8 +208,11 @@
                                 </button>
                             </div>
                         </div>
-                        <audio id="note-audio-player" class="audio-player" controls style="display:none;margin-top:4px;"></audio>
+                        <button class="collapse-toggle" aria-label="Toggle note tools">
+                            <i class="fas fa-chevron-up"></i>
+                        </button>
                     </div>
+                    <audio id="note-audio-player" class="audio-player" controls style="display:none;margin-top:4px;"></audio>
                 </div>
 
                 <div class="note-tags" id="note-tags"></div>

--- a/style.css
+++ b/style.css
@@ -1174,6 +1174,18 @@ select.form-control {
     gap: var(--space-12);
 }
 
+/* Align note title and actions on a single line */
+#note-header .section-header {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: var(--space-8);
+}
+
+#note-header .section-header .editor-actions {
+    justify-self: center;
+}
+
 .note-title {
     flex: 1;
     font-size: var(--font-size-lg);
@@ -1628,6 +1640,16 @@ select.form-control {
         flex-direction: column;
         align-items: stretch;
         gap: var(--space-12);
+    }
+
+    #note-header .section-header {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    #note-header .section-header .editor-actions {
+        width: 100%;
     }
     
     .editor-actions {


### PR DESCRIPTION
## Summary
- align note header buttons on a single row with the title
- center buttons using CSS grid
- keep mobile layout stacked

## Testing
- `pytest -q` *(fails: DATABASE_URL environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_6877c87e6efc832eb32f7e991d73eaa2