### PR TITLE
Fix graph modal controls alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,27 +310,29 @@
             <div class="modal-body">
                 <div class="graph-container" id="graph-container"></div>
                 <div class="graph-text-output hidden" id="graph-text-output"></div>
-                <div class="checkbox-group">
-                    <label class="checkbox-label">
-                        <input type="checkbox" id="graph-text-toggle">
-                        <span class="checkmark"></span>
-                        Text exploration
-                    </label>
-                </div>
-                <div class="graph-controls">
-                    <select class="form-control" id="graph-type-select">
-                        <option value="mindmap" selected>Mindmap</option>
-                        <option value="timeline">Timeline</option>
-                        <option value="treemap">Treemap</option>
-                        <option value="radar">Radar</option>
-                        <option value="sequence">Sequence</option>
-                        <option value="user journey">User journey</option>
-                        <option value="pie chart">Pie chart</option>
-                    </select>
-                    <button class="btn btn--outline btn--sm" id="regenerate-graph-btn" title="Regenerate graph">↻</button>
-                </div>
             </div>
             <div class="modal-actions">
+                <div class="graph-options">
+                    <div class="checkbox-group">
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="graph-text-toggle">
+                            <span class="checkmark"></span>
+                            Text exploration
+                        </label>
+                    </div>
+                    <div class="graph-controls">
+                        <select class="form-control" id="graph-type-select">
+                            <option value="mindmap" selected>Mindmap</option>
+                            <option value="timeline">Timeline</option>
+                            <option value="treemap">Treemap</option>
+                            <option value="radar">Radar</option>
+                            <option value="sequence">Sequence</option>
+                            <option value="user journey">User journey</option>
+                            <option value="pie chart">Pie chart</option>
+                        </select>
+                        <button class="btn btn--outline btn--sm" id="regenerate-graph-btn" title="Regenerate graph">↻</button>
+                    </div>
+                </div>
                 <button class="btn btn--outline btn--sm" id="prev-graph-btn" title="Previous graph">
                     <i class="fas fa-arrow-left"></i>
                 </button>

--- a/style.css
+++ b/style.css
@@ -2877,6 +2877,18 @@ select.form-control {
     margin-left: var(--space-8);
 }
 
+/* Left aligned controls in graph modal */
+.graph-options {
+    display: flex;
+    align-items: center;
+    gap: var(--space-12);
+    margin-right: auto;
+}
+
+.graph-options .checkbox-group {
+    margin: 0;
+}
+
 /* Audio files list */
 #audio-file-list {
     list-style: none;


### PR DESCRIPTION
## Summary
- align text exploration, graph type dropdown and regeneration button horizontally with other graph modal controls

## Testing
- `pytest -q` *(fails: ConnectionPool couldn't get a connection)*

------
https://chatgpt.com/codex/tasks/task_e_6877cc919760832e8634f70f61a2c201