### PR TITLE
UI fix: embed audio player in action bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,12 +207,12 @@
                                     <i class="fas fa-play"></i>
                                 </button>
                             </div>
+                            <audio id="note-audio-player" class="audio-player" controls style="display:none;"></audio>
                         </div>
                         <button class="collapse-toggle" aria-label="Toggle note tools">
                             <i class="fas fa-chevron-up"></i>
                         </button>
                     </div>
-                    <audio id="note-audio-player" class="audio-player" controls style="display:none;margin-top:4px;"></audio>
                 </div>
 
                 <div class="note-tags" id="note-tags"></div>

--- a/style.css
+++ b/style.css
@@ -1226,6 +1226,11 @@ select.form-control {
     width: 100%;
     margin-top: var(--space-8);
     flex: 0 0 100%;
+    height: 32px;
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    accent-color: var(--color-primary);
 }
 
 .formatting-toolbar {


### PR DESCRIPTION
## Summary
- move the note audio player into the header action bar
- style the player to be small and match the app theme

## Testing
- `pytest -q` *(fails: couldn't get a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_6877cfcbe6a0832ebf0afba8a6bf0609