### PR TITLE
Fix reverse proxy login redirects

### DIFF
--- a/app.js
+++ b/app.js
@@ -5265,7 +5265,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (multiUser) {
         const restored = await restoreSession();
         if (!restored) {
-            window.location.href = '/login.html';
+            window.location.href = 'login.html';
             return;
         }
     } else {
@@ -5339,7 +5339,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (noteTitle) noteTitle.value = '';
         document.querySelector('.editor-container')?.classList.add('hidden');
         if (multiUser) {
-            window.location.href = '/login.html';
+            window.location.href = 'login.html';
         } else {
             // Force a full page reload to ensure all state is cleared
             window.location.reload(true);

--- a/backend-api.js
+++ b/backend-api.js
@@ -1,5 +1,5 @@
-// Configuración del backend - usa rutas relativas ya que nginx hace el proxy
-const BACKEND_URL = '';
+// Configuración del backend - usa el mismo prefijo que la página actual
+const BACKEND_URL = window.location.pathname.replace(/\/[^\/]*$/, '');
 
 // Clase para manejar las llamadas al backend
 class BackendAPI {

--- a/login.js
+++ b/login.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     if (!multiUser) {
-        window.location.href = '/index.html';
+        window.location.href = 'index.html';
         return;
     }
 
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const session = JSON.parse(saved);
             const resp = await fetch('/api/session-info', { headers: { 'Authorization': session.token } });
             if (resp.ok) {
-                window.location.href = '/index.html';
+                window.location.href = 'index.html';
                 return true;
             }
         } catch {}
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (resp.ok) {
                 const data = await resp.json();
                 localStorage.setItem('notes-app-session', JSON.stringify({ token: data.token }));
-                window.location.href = '/index.html';
+                window.location.href = 'index.html';
             } else {
                 alert('Login failed');
             }


### PR DESCRIPTION
## Summary
- support deployments behind a base path
- use relative redirects in `login.js` and `app.js`
- compute API base URL dynamically in `backend-api.js`

## Testing
- `PYTHONPATH=. pytest tests/test_auth.py tests/test_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6878aa4d0aa8832e8122e8660deaff77