### PR TITLE
Fix login redirect behind proxy

### DIFF
--- a/app.js
+++ b/app.js
@@ -5265,7 +5265,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (multiUser) {
         const restored = await restoreSession();
         if (!restored) {
-            window.location.href = '/login.html';
+            window.location.href = 'login.html';
             return;
         }
     } else {
@@ -5339,7 +5339,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (noteTitle) noteTitle.value = '';
         document.querySelector('.editor-container')?.classList.add('hidden');
         if (multiUser) {
-            window.location.href = '/login.html';
+            window.location.href = 'login.html';
         } else {
             // Force a full page reload to ensure all state is cleared
             window.location.reload(true);

--- a/login.js
+++ b/login.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     if (!multiUser) {
-        window.location.href = '/index.html';
+        window.location.href = 'index.html';
         return;
     }
 
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const session = JSON.parse(saved);
             const resp = await fetch('/api/session-info', { headers: { 'Authorization': session.token } });
             if (resp.ok) {
-                window.location.href = '/index.html';
+                window.location.href = 'index.html';
                 return true;
             }
         } catch {}
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (resp.ok) {
                 const data = await resp.json();
                 localStorage.setItem('notes-app-session', JSON.stringify({ token: data.token }));
-                window.location.href = '/index.html';
+                window.location.href = 'index.html';
             } else {
                 alert('Login failed');
             }


### PR DESCRIPTION
## Summary
- adjust redirects in `app.js` and `login.js` to use relative paths so the UI loads correctly when served from a subpath
- install dependencies for running tests

## Testing
- `pip install -r requirements.txt`
- `service postgresql start`
- `sudo -u postgres psql -c "CREATE USER whispad WITH PASSWORD 'change_me';" && sudo -u postgres psql -c "CREATE DATABASE whispad OWNER whispad;" && sudo -u postgres psql -d whispad -c "CREATE EXTENSION IF NOT EXISTS pgcrypto;"`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878bc04f054832e8344038bb387689d