### PR TITLE
Add retranscription button

### DIFF
--- a/app.js
+++ b/app.js
@@ -390,6 +390,14 @@ class NotesApp {
             });
         }
 
+        const reprocessBtn = document.getElementById('reprocess-audio-btn');
+        if (reprocessBtn) {
+            reprocessBtn.addEventListener('click', () => {
+                this.captureInsertionRange();
+                this.reprocessSelectedAudio();
+            });
+        }
+
         const refreshBtn = document.getElementById('refresh-audio-btn');
         if (refreshBtn) {
             refreshBtn.addEventListener('click', () => {
@@ -3431,6 +3439,20 @@ class NotesApp {
             await player.play();
         } catch (err) {
             console.error('Audio play error', err);
+        }
+    }
+
+    async reprocessSelectedAudio() {
+        const select = document.getElementById('audio-select');
+        if (!select || !select.value) return;
+
+        try {
+            const resp = await authFetch(`/api/get-audio?filename=${encodeURIComponent(select.value)}`);
+            if (!resp.ok) throw new Error('Failed to fetch audio');
+            const blob = await resp.blob();
+            await this.transcribeAudio(blob);
+        } catch (err) {
+            console.error('Error retranscribing audio', err);
         }
     }
     

--- a/index.html
+++ b/index.html
@@ -207,6 +207,9 @@
                                 <button class="btn btn--outline btn--sm" id="play-audio-btn" title="Play audio">
                                     <i class="fas fa-play"></i>
                                 </button>
+                                <button class="btn btn--outline btn--sm" id="reprocess-audio-btn" title="Retranscribe audio">
+                                    <i class="fas fa-redo"></i>
+                                </button>
                             </div>
                             <audio id="note-audio-player" class="audio-player" controls style="display:none;"></audio>
                         </div>


### PR DESCRIPTION
## Summary
- add retranscription button beside Play
- fetch stored audio and send it through existing transcription pipeline

## Testing
- `pytest -q` *(fails: Database connection not available)*

------
https://chatgpt.com/codex/tasks/task_e_687b6a8fec90832e94c259dd462a703c