### PR TITLE
Add reprocess audio button

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -3189,6 +3189,8 @@ def upload_audio():
         provider = request.form.get('provider', 'openai')
         model = request.form.get('model')
 
+        skip_save = request.form.get('skip_save', 'false').lower() == 'true'
+
         detect_emotion = request.form.get('detect_emotion', 'true').lower() == 'true'
         detect_events = request.form.get('detect_events', 'true').lower() == 'true'
         use_itn = request.form.get('use_itn', 'true').lower() == 'true'
@@ -3238,6 +3240,9 @@ def upload_audio():
                 transcription = response.json().get('text', '')
             else:
                 return jsonify({"error": "Error en la transcripción"}), response.status_code
+
+        if skip_save:
+            return jsonify({"success": True, "transcription": transcription})
 
         # Convert and save WAV file
         with tempfile.NamedTemporaryFile(suffix=f".{audio_file.filename.split('.')[-1]}", delete=False) as tmp:

--- a/index.html
+++ b/index.html
@@ -207,6 +207,9 @@
                                 <button class="btn btn--outline btn--sm" id="play-audio-btn" title="Play audio">
                                     <i class="fas fa-play"></i>
                                 </button>
+                                <button class="btn btn--outline btn--sm" id="reprocess-audio-btn" title="Reprocess audio">
+                                    <i class="fas fa-rotate-right"></i>
+                                </button>
                             </div>
                             <audio id="note-audio-player" class="audio-player" controls style="display:none;"></audio>
                         </div>


### PR DESCRIPTION
## Summary
- add reprocess button in note toolbar
- allow /api/upload-audio to skip saving the file
- support reprocessing of a saved audio on the frontend

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: couldn't get a connection from the pool)*

------
https://chatgpt.com/codex/tasks/task_e_687b7a90880c832ebd6165ea863d49c3