### PR TITLE
Add diarization fix style

### DIFF
--- a/app.js
+++ b/app.js
@@ -100,6 +100,13 @@ const configuracionMejoras = {
         prompt: "Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:",
         visible: true
     },
+    diarization_fix: {
+        nombre: "Fix Speaker Tags",
+        descripcion: "Corrects speaker diarization tags",
+        icono: "👥",
+        prompt: "Correct the speaker diarization in this transcript. Some speaker tags may be incorrectly placed. You MUST NOT modify the text content, only adjust the position of the speaker tags or the text itself. Keep the tags in the format [SPEAKER X]. Respond ONLY with the fixed diarization text, without additional explanations:",
+        visible: true
+    },
     translation: {
         nombre: "Translation",
         descripcion: "Translate text into another language",
@@ -3886,8 +3893,13 @@ class NotesApp {
                             }
                             if (data.done) {
                                 console.log('Stream marked as done');
-                                const finalText = this.cleanAIResponse(state.improvedText);
-                                tempElement.textContent = finalText;
+                                let finalText = this.cleanAIResponse(state.improvedText);
+                                if (action === 'diarization_fix') {
+                                    finalText = this.formatDiarizationTags(finalText);
+                                    tempElement.innerHTML = finalText.replace(/\n/g, '<br>');
+                                } else {
+                                    tempElement.textContent = finalText;
+                                }
                                 console.log('Final text set:', finalText);
 
                                 tempElement.className = 'ai-generated-text';
@@ -3909,7 +3921,10 @@ class NotesApp {
                 }
             }
             
-            const finalResult = this.cleanAIResponse(state.improvedText);
+            let finalResult = this.cleanAIResponse(state.improvedText);
+            if (action === 'diarization_fix') {
+                finalResult = this.formatDiarizationTags(finalResult);
+            }
             console.log('Returning final result:', finalResult);
             return finalResult;
         } catch (error) {
@@ -3977,8 +3992,13 @@ class NotesApp {
                             if (data.done) {
                                 console.log('Gemini stream marked as done');
                                 // Asegurar que el texto final esté limpio
-                                const finalText = this.cleanAIResponse(state.improvedText);
-                                tempElement.textContent = finalText;
+                                let finalText = this.cleanAIResponse(state.improvedText);
+                                if (action === 'diarization_fix') {
+                                    finalText = this.formatDiarizationTags(finalText);
+                                    tempElement.innerHTML = finalText.replace(/\n/g, '<br>');
+                                } else {
+                                    tempElement.textContent = finalText;
+                                }
                                 console.log('Final Gemini text set:', finalText);
                                 
                                 // Cambiar a clase de texto completado
@@ -4004,7 +4024,10 @@ class NotesApp {
                 }
             }
             
-            const finalResult = this.cleanAIResponse(state.improvedText);
+            let finalResult = this.cleanAIResponse(state.improvedText);
+            if (action === 'diarization_fix') {
+                finalResult = this.formatDiarizationTags(finalResult);
+            }
             console.log('Returning final Gemini result:', finalResult);
             return finalResult;
         } catch (error) {
@@ -4115,8 +4138,13 @@ class NotesApp {
                             if (data.done) {
                                 console.log('OpenRouter stream marked as done');
                                 // Asegurar que el texto final esté limpio
-                                const finalText = this.cleanAIResponse(state.improvedText);
-                                tempElement.textContent = finalText;
+                                let finalText = this.cleanAIResponse(state.improvedText);
+                                if (action === 'diarization_fix') {
+                                    finalText = this.formatDiarizationTags(finalText);
+                                    tempElement.innerHTML = finalText.replace(/\n/g, '<br>');
+                                } else {
+                                    tempElement.textContent = finalText;
+                                }
                                 console.log('Final OpenRouter text set:', finalText);
                                 
                                 // Cambiar a clase de texto completado
@@ -4142,7 +4170,10 @@ class NotesApp {
                 }
             }
             
-            const finalResult = this.cleanAIResponse(state.improvedText);
+            let finalResult = this.cleanAIResponse(state.improvedText);
+            if (action === 'diarization_fix') {
+                finalResult = this.formatDiarizationTags(finalResult);
+            }
             console.log('Returning final OpenRouter result:', finalResult);
             return finalResult;
         } catch (error) {
@@ -4198,8 +4229,13 @@ class NotesApp {
                             }
                             if (data.done) {
                                 console.log('Groq stream marked as done');
-                                const finalText = this.cleanAIResponse(state.improvedText);
-                                tempElement.textContent = finalText;
+                                let finalText = this.cleanAIResponse(state.improvedText);
+                                if (action === 'diarization_fix') {
+                                    finalText = this.formatDiarizationTags(finalText);
+                                    tempElement.innerHTML = finalText.replace(/\n/g, '<br>');
+                                } else {
+                                    tempElement.textContent = finalText;
+                                }
                                 tempElement.className = 'ai-generated-text';
                                 setTimeout(() => { tempElement.className = ''; }, 1000);
                                 return finalText;
@@ -4216,7 +4252,10 @@ class NotesApp {
                 }
             }
 
-            const finalResult = this.cleanAIResponse(state.improvedText);
+            let finalResult = this.cleanAIResponse(state.improvedText);
+            if (action === 'diarization_fix') {
+                finalResult = this.formatDiarizationTags(finalResult);
+            }
             console.log('Returning final Groq result:', finalResult);
             return finalResult;
         } catch (error) {
@@ -4263,8 +4302,13 @@ class NotesApp {
                                 tempElement.className = 'ai-generating-text';
                             }
                             if (data.done) {
-                                const finalText = this.cleanAIResponse(state.improvedText);
-                                tempElement.textContent = finalText;
+                                let finalText = this.cleanAIResponse(state.improvedText);
+                                if (action === 'diarization_fix') {
+                                    finalText = this.formatDiarizationTags(finalText);
+                                    tempElement.innerHTML = finalText.replace(/\n/g, '<br>');
+                                } else {
+                                    tempElement.textContent = finalText;
+                                }
                                 tempElement.className = 'ai-generated-text';
                                 setTimeout(() => { tempElement.className = ''; }, 1000);
                                 return finalText;
@@ -4279,7 +4323,10 @@ class NotesApp {
                 }
             }
 
-            const finalResult = this.cleanAIResponse(state.improvedText);
+            let finalResult = this.cleanAIResponse(state.improvedText);
+            if (action === 'diarization_fix') {
+                finalResult = this.formatDiarizationTags(finalResult);
+            }
             return finalResult;
         } catch (error) {
             console.error('Error in improveWithLmStudioStream:', error);
@@ -4325,8 +4372,13 @@ class NotesApp {
                                 tempElement.className = 'ai-generating-text';
                             }
                             if (data.done) {
-                                const finalText = this.cleanAIResponse(state.improvedText);
-                                tempElement.textContent = finalText;
+                                let finalText = this.cleanAIResponse(state.improvedText);
+                                if (action === 'diarization_fix') {
+                                    finalText = this.formatDiarizationTags(finalText);
+                                    tempElement.innerHTML = finalText.replace(/\n/g, '<br>');
+                                } else {
+                                    tempElement.textContent = finalText;
+                                }
                                 tempElement.className = 'ai-generated-text';
                                 setTimeout(() => { tempElement.className = ''; }, 1000);
                                 return finalText;
@@ -4341,7 +4393,10 @@ class NotesApp {
                 }
             }
 
-            const finalResult = this.cleanAIResponse(state.improvedText);
+            let finalResult = this.cleanAIResponse(state.improvedText);
+            if (action === 'diarization_fix') {
+                finalResult = this.formatDiarizationTags(finalResult);
+            }
             return finalResult;
         } catch (error) {
             console.error('Error in improveWithOllamaStream:', error);
@@ -4389,6 +4444,29 @@ class NotesApp {
         console.log('cleanAIResponse output:', cleaned.substring(0, 100) + '...');
 
         return cleaned;
+    }
+
+    // Format speaker tags: place each [SPEAKER X] on a new line and remove
+    // duplicate tags for the same speaker within a single line
+    formatDiarizationTags(text) {
+        if (!text) return '';
+        let normalized = text.replace(/\[speaker\s*(\d+)\]/gi, '[SPEAKER $1]');
+        const parts = normalized.split(/(\[SPEAKER\s*\d+\])/i).filter(p => p);
+        let result = '';
+        let current = null;
+        for (const part of parts) {
+            if (/^\[SPEAKER\s*\d+\]$/i.test(part)) {
+                const tag = part.toUpperCase();
+                if (tag !== current) {
+                    if (result) result += '\n\n';
+                    result += tag;
+                    current = tag;
+                }
+            } else {
+                result += ' ' + part.trim();
+            }
+        }
+        return result.trim();
     }
 
     // Handle streaming chunks that may contain <think>...</think> segments
@@ -4543,6 +4621,9 @@ class NotesApp {
             },
             expand: (texto) => {
                 return texto + ' [Se han añadido detalles adicionales y contexto relevante para enriquecer el contenido y proporcionar una comprensión más completa del tema tratado.]';
+            },
+            diarization_fix: (texto) => {
+                return this.formatDiarizationTags(texto);
             }
         };
         

--- a/backend.py
+++ b/backend.py
@@ -780,7 +780,7 @@ def improve_text_openai(text, improvement_type, model, custom_prompt=None):
     
     # Si se proporciona un prompt personalizado, usarlo directamente
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}"
+        prompt = f"{custom_prompt}\n\n{text}",
     else:
         # Definir prompts según el tipo de mejora (solo para estilos predeterminados)
         prompts = {
@@ -791,7 +791,8 @@ def improve_text_openai(text, improvement_type, model, custom_prompt=None):
             'narrative': f"Improve the following narrative text or novel dialogue, preserving the literary style and narrative voice. Enhance flow, description and literary quality while keeping the essence of the text. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'academic_v2': f"Improve the following academic text by making minimal changes to preserve the author's words. Use more precise wording when necessary, improve the structure and remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Keep the original style and vocabulary as much as possible. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'summarize': f"Create a concise summary of the following text. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the summary, without additional explanations:\n\n{text}",
-            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}"
+            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}",
+            'diarization_fix': f"Correct the speaker diarization in this transcript. Some speaker tags may be incorrectly placed. You MUST NOT modify the text content, only adjust the position of the speaker tags or the text itself. Keep the tags in the format [SPEAKER X]. Respond ONLY with the fixed diarization text, without additional explanations:\n\n{text}",
         }
         
         prompt = prompts.get(improvement_type, f"Improve the following text: {text}")
@@ -836,7 +837,7 @@ def improve_text_google(text, improvement_type, model, custom_prompt=None):
     
     # Si se proporciona un prompt personalizado, usarlo directamente
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}"
+        prompt = f"{custom_prompt}\n\n{text}",
     else:
         # Definir prompts según el tipo de mejora (solo para estilos predeterminados)
         prompts = {
@@ -847,7 +848,8 @@ def improve_text_google(text, improvement_type, model, custom_prompt=None):
             'narrative': f"Improve the following narrative text or novel dialogue, preserving the literary style and narrative voice. Enhance flow, description and literary quality while keeping the essence of the text. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'academic_v2': f"Improve the following academic text by making minimal changes to preserve the author's words. Use more precise wording when necessary, improve the structure and remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Keep the original style and vocabulary as much as possible. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'summarize': f"Create a concise summary of the following text. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the summary, without additional explanations:\n\n{text}",
-            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}"
+            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}",
+            'diarization_fix': f"Correct the speaker diarization in this transcript. Some speaker tags may be incorrectly placed. You MUST NOT modify the text content, only adjust the position of the speaker tags or the text itself. Keep the tags in the format [SPEAKER X]. Respond ONLY with the fixed diarization text, without additional explanations:\n\n{text}",
         }
         
         prompt = prompts.get(improvement_type, f"Improve the following text: {text}")
@@ -884,7 +886,7 @@ def improve_text_openai_stream(text, improvement_type, model, custom_prompt=None
     
     # Si se proporciona un prompt personalizado, usarlo directamente
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}"
+        prompt = f"{custom_prompt}\n\n{text}",
     else:
         # Definir prompts según el tipo de mejora (solo para estilos predeterminados)
         prompts = {
@@ -895,7 +897,8 @@ def improve_text_openai_stream(text, improvement_type, model, custom_prompt=None
             'narrative': f"Improve the following narrative text or novel dialogue, preserving the literary style and narrative voice. Enhance flow, description and literary quality while keeping the essence of the text. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'academic_v2': f"Improve the following academic text by making minimal changes to preserve the author's words. Use more precise wording when necessary, improve the structure and remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Keep the original style and vocabulary as much as possible. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'summarize': f"Create a concise summary of the following text. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the summary, without additional explanations:\n\n{text}",
-            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}"
+            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}",
+            'diarization_fix': f"Correct the speaker diarization in this transcript. Some speaker tags may be incorrectly placed. You MUST NOT modify the text content, only adjust the position of the speaker tags or the text itself. Keep the tags in the format [SPEAKER X]. Respond ONLY with the fixed diarization text, without additional explanations:\n\n{text}",
         }
         
         prompt = prompts.get(improvement_type, f"Improve the following text: {text}")
@@ -970,7 +973,7 @@ def improve_text_google_stream(text, improvement_type, model, custom_prompt=None
     
     # Si se proporciona un prompt personalizado, usarlo directamente
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}"
+        prompt = f"{custom_prompt}\n\n{text}",
     else:
         # Definir prompts según el tipo de mejora (solo para estilos predeterminados)
         prompts = {
@@ -981,7 +984,8 @@ def improve_text_google_stream(text, improvement_type, model, custom_prompt=None
             'narrative': f"Improve the following narrative text or novel dialogue, preserving the literary style and narrative voice. Enhance flow, description and literary quality while keeping the essence of the text. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'academic_v2': f"Improve the following academic text by making minimal changes to preserve the author's words. Use more precise wording when necessary, improve the structure and remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Keep the original style and vocabulary as much as possible. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'summarize': f"Create a concise summary of the following text. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the summary, without additional explanations:\n\n{text}",
-            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}"
+            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}",
+            'diarization_fix': f"Correct the speaker diarization in this transcript. Some speaker tags may be incorrectly placed. You MUST NOT modify the text content, only adjust the position of the speaker tags or the text itself. Keep the tags in the format [SPEAKER X]. Respond ONLY with the fixed diarization text, without additional explanations:\n\n{text}",
         }
         
         prompt = prompts.get(improvement_type, f"Improve the following text: {text}")
@@ -1051,7 +1055,7 @@ def improve_text_openrouter(text, improvement_type, model, custom_prompt=None):
     
     # Si se proporciona un prompt personalizado, usarlo directamente
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}"
+        prompt = f"{custom_prompt}\n\n{text}",
     else:
         # Definir prompts según el tipo de mejora (solo para estilos predeterminados)
         prompts = {
@@ -1062,7 +1066,8 @@ def improve_text_openrouter(text, improvement_type, model, custom_prompt=None):
             'narrative': f"Improve the following narrative text or novel dialogue, preserving the literary style and narrative voice. Enhance flow, description and literary quality while keeping the essence of the text. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'academic_v2': f"Improve the following academic text by making minimal changes to preserve the author's words. Use more precise wording when necessary, improve the structure and remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Keep the original style and vocabulary as much as possible. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'summarize': f"Create a concise summary of the following text. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the summary, without additional explanations:\n\n{text}",
-            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}"
+            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}",
+            'diarization_fix': f"Correct the speaker diarization in this transcript. Some speaker tags may be incorrectly placed. You MUST NOT modify the text content, only adjust the position of the speaker tags or the text itself. Keep the tags in the format [SPEAKER X]. Respond ONLY with the fixed diarization text, without additional explanations:\n\n{text}",
         }
         
         prompt = prompts.get(improvement_type, f"Improve the following text: {text}")
@@ -1126,7 +1131,7 @@ def improve_text_openrouter_stream(text, improvement_type, model, custom_prompt=
     
     # Si se proporciona un prompt personalizado, usarlo directamente
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}"
+        prompt = f"{custom_prompt}\n\n{text}",
     else:
         # Definir prompts según el tipo de mejora (solo para estilos predeterminados)
         prompts = {
@@ -1137,7 +1142,8 @@ def improve_text_openrouter_stream(text, improvement_type, model, custom_prompt=
             'narrative': f"Improve the following narrative text or novel dialogue, preserving the literary style and narrative voice. Enhance flow, description and literary quality while keeping the essence of the text. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'academic_v2': f"Improve the following academic text by making minimal changes to preserve the author's words. Use more precise wording when necessary, improve the structure and remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Keep the original style and vocabulary as much as possible. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'summarize': f"Create a concise summary of the following text. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the summary, without additional explanations:\n\n{text}",
-            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}"
+            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}",
+            'diarization_fix': f"Correct the speaker diarization in this transcript. Some speaker tags may be incorrectly placed. You MUST NOT modify the text content, only adjust the position of the speaker tags or the text itself. Keep the tags in the format [SPEAKER X]. Respond ONLY with the fixed diarization text, without additional explanations:\n\n{text}",
         }
         
         prompt = prompts.get(improvement_type, f"Improve the following text: {text}")
@@ -1216,7 +1222,7 @@ def improve_text_groq(text, improvement_type, model, custom_prompt=None):
         return jsonify({"error": "Model not specified"}), 400
 
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}"
+        prompt = f"{custom_prompt}\n\n{text}",
     else:
         prompts = {
             'clarity': f"Rewrite the following text in a clearer and more readable way. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking aloud. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
@@ -1226,7 +1232,8 @@ def improve_text_groq(text, improvement_type, model, custom_prompt=None):
             'narrative': f"Improve the following narrative text or novel dialogue, preserving the literary style and narrative voice. Enhance flow, description and literary quality while keeping the essence of the text. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'academic_v2': f"Improve the following academic text by making minimal changes to preserve the author's words. Use more precise wording when necessary, improve the structure and remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking aloud. Keep the original style and vocabulary as much as possible. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'summarize': f"Create a concise summary of the following text. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking aloud. Respond ONLY with the summary, without additional explanations:\n\n{text}",
-            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}"
+            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}",
+            'diarization_fix': f"Correct the speaker diarization in this transcript. Some speaker tags may be incorrectly placed. You MUST NOT modify the text content, only adjust the position of the speaker tags or the text itself. Keep the tags in the format [SPEAKER X]. Respond ONLY with the fixed diarization text, without additional explanations:\n\n{text}",
         }
 
         prompt = prompts.get(improvement_type, f"Improve the following text: {text}")
@@ -1270,7 +1277,7 @@ def improve_text_groq_stream(text, improvement_type, model, custom_prompt=None):
         return Response(generate_error(), mimetype='text/event-stream', headers={'Cache-Control': 'no-cache'})
 
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}"
+        prompt = f"{custom_prompt}\n\n{text}",
     else:
         prompts = {
             'clarity': f"Rewrite the following text in a clearer and more readable way. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking aloud. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
@@ -1280,7 +1287,8 @@ def improve_text_groq_stream(text, improvement_type, model, custom_prompt=None):
             'narrative': f"Improve the following narrative text or novel dialogue, preserving the literary style and narrative voice. Enhance flow, description and literary quality while keeping the essence of the text. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'academic_v2': f"Improve the following academic text by making minimal changes to preserve the author's words. Use more precise wording when necessary, improve the structure and remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking aloud. Keep the original style and vocabulary as much as possible. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'summarize': f"Create a concise summary of the following text. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking aloud. Respond ONLY with the summary, without additional explanations:\n\n{text}",
-            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}"
+            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}",
+            'diarization_fix': f"Correct the speaker diarization in this transcript. Some speaker tags may be incorrectly placed. You MUST NOT modify the text content, only adjust the position of the speaker tags or the text itself. Keep the tags in the format [SPEAKER X]. Respond ONLY with the fixed diarization text, without additional explanations:\n\n{text}",
         }
 
         prompt = prompts.get(improvement_type, f"Improve the following text: {text}")
@@ -1336,7 +1344,7 @@ def improve_text_lmstudio(text, improvement_type, model, host, port, custom_prom
         return jsonify({"error": "LM Studio host, port and model required"}), 400
 
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}"
+        prompt = f"{custom_prompt}\n\n{text}",
     else:
         prompts = {
             'clarity': f"Rewrite the following text in a clearer and more readable way. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
@@ -1346,7 +1354,8 @@ def improve_text_lmstudio(text, improvement_type, model, host, port, custom_prom
             'narrative': f"Improve the following narrative text or novel dialogue, preserving the literary style and narrative voice. Enhance flow, description and literary quality while keeping the essence of the text. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'academic_v2': f"Improve the following academic text by making minimal changes to preserve the author's words. Use more precise wording when necessary, improve the structure and remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Keep the original style and vocabulary as much as possible. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'summarize': f"Create a concise summary of the following text. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the summary, without additional explanations:\n\n{text}",
-            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}"
+            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}",
+            'diarization_fix': f"Correct the speaker diarization in this transcript. Some speaker tags may be incorrectly placed. You MUST NOT modify the text content, only adjust the position of the speaker tags or the text itself. Keep the tags in the format [SPEAKER X]. Respond ONLY with the fixed diarization text, without additional explanations:\n\n{text}",
         }
 
         prompt = prompts.get(improvement_type, f"Improve the following text: {text}")
@@ -1399,7 +1408,7 @@ def improve_text_lmstudio_stream(text, improvement_type, model, host, port, cust
         return Response(generate_error(), mimetype='text/event-stream', headers={'Cache-Control': 'no-cache'})
 
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}"
+        prompt = f"{custom_prompt}\n\n{text}",
     else:
         prompts = {
             'clarity': f"Rewrite the following text in a clearer and more readable way. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
@@ -1409,7 +1418,8 @@ def improve_text_lmstudio_stream(text, improvement_type, model, host, port, cust
             'narrative': f"Improve the following narrative text or novel dialogue, preserving the literary style and narrative voice. Enhance flow, description and literary quality while keeping the essence of the text. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'academic_v2': f"Improve the following academic text by making minimal changes to preserve the author's words. Use more precise wording when necessary, improve the structure and remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Keep the original style and vocabulary as much as possible. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'summarize': f"Create a concise summary of the following text. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the summary, without additional explanations:\n\n{text}",
-            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}"
+            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}",
+            'diarization_fix': f"Correct the speaker diarization in this transcript. Some speaker tags may be incorrectly placed. You MUST NOT modify the text content, only adjust the position of the speaker tags or the text itself. Keep the tags in the format [SPEAKER X]. Respond ONLY with the fixed diarization text, without additional explanations:\n\n{text}",
         }
 
         prompt = prompts.get(improvement_type, f"Improve the following text: {text}")
@@ -1460,7 +1470,7 @@ def improve_text_ollama(text, improvement_type, model, host, port, custom_prompt
         return jsonify({"error": "Ollama host, port and model required"}), 400
 
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}"
+        prompt = f"{custom_prompt}\n\n{text}",
     else:
         prompts = {
             'clarity': f"Rewrite the following text in a clearer and more readable way. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
@@ -1470,7 +1480,8 @@ def improve_text_ollama(text, improvement_type, model, host, port, custom_prompt
             'narrative': f"Improve the following narrative text or novel dialogue, preserving the literary style and narrative voice. Enhance flow, description and literary quality while keeping the essence of the text. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'academic_v2': f"Improve the following academic text by making minimal changes to preserve the author's words. Use more precise wording when necessary, improve the structure and remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Keep the original style and vocabulary as much as possible. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'summarize': f"Create a concise summary of the following text. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the summary, without additional explanations:\n\n{text}",
-            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}"
+            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}",
+            'diarization_fix': f"Correct the speaker diarization in this transcript. Some speaker tags may be incorrectly placed. You MUST NOT modify the text content, only adjust the position of the speaker tags or the text itself. Keep the tags in the format [SPEAKER X]. Respond ONLY with the fixed diarization text, without additional explanations:\n\n{text}",
         }
 
         prompt = prompts.get(improvement_type, f"Improve the following text: {text}")
@@ -1503,7 +1514,7 @@ def improve_text_ollama_stream(text, improvement_type, model, host, port, custom
         return Response(generate_error(), mimetype='text/event-stream', headers={'Cache-Control': 'no-cache'})
 
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}"
+        prompt = f"{custom_prompt}\n\n{text}",
     else:
         prompts = {
             'clarity': f"Rewrite the following text in a clearer and more readable way. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
@@ -1513,7 +1524,8 @@ def improve_text_ollama_stream(text, improvement_type, model, host, port, custom
             'narrative': f"Improve the following narrative text or novel dialogue, preserving the literary style and narrative voice. Enhance flow, description and literary quality while keeping the essence of the text. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'academic_v2': f"Improve the following academic text by making minimal changes to preserve the author's words. Use more precise wording when necessary, improve the structure and remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Keep the original style and vocabulary as much as possible. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
             'summarize': f"Create a concise summary of the following text. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the summary, without additional explanations:\n\n{text}",
-            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}"
+            'expand': f"Expand the following text by adding more details and relevant context. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the expanded text, without additional explanations:\n\n{text}",
+            'diarization_fix': f"Correct the speaker diarization in this transcript. Some speaker tags may be incorrectly placed. You MUST NOT modify the text content, only adjust the position of the speaker tags or the text itself. Keep the tags in the format [SPEAKER X]. Respond ONLY with the fixed diarization text, without additional explanations:\n\n{text}",
         }
 
         prompt = prompts.get(improvement_type, f"Improve the following text: {text}")


### PR DESCRIPTION
## Summary
- add new diarization_fix AI style on frontend
- add diarization formatting helper
- integrate diarization_fix into AI workflows
- support diarization_fix style prompts in backend

## Testing
- `pytest -q` *(fails: DATABASE_URL not set)*

------
https://chatgpt.com/codex/tasks/task_e_687cbdef3fb0832e827335f5223dd3e8