### PR TITLE
Show editor during streaming

### DIFF
--- a/style.css
+++ b/style.css
@@ -1298,6 +1298,11 @@ select.form-control {
     min-height: 300px;
 }
 
+.editor.read-only {
+    background-color: var(--color-surface);
+    cursor: default;
+}
+
 @media (max-width: 768px) {
     .editor {
         font-size: 16px;


### PR DESCRIPTION
## Summary
- prevent overlay from hiding editor during streaming uploads
- make editor read-only during chunked recording or streaming uploads
- allow scroll while streaming by toggling a read-only class

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687ce1eb039c832e90249936cce9b49f