### PR TITLE
Fix user styles persistence

### DIFF
--- a/app.js
+++ b/app.js
@@ -205,7 +205,7 @@ class NotesApp {
     }
     
     async init() {
-        this.loadConfig();
+        await this.loadConfig();
         this.loadStylesConfig();
         this.updateTranslationStyle();
         this.storeDefaultLanguageOptions();
@@ -908,11 +908,24 @@ class NotesApp {
     }
 
     // Configuración
-    loadConfig() {
+    async loadConfig() {
         const storageKey = `notes-app-config-${currentUser}`;
         const saved = localStorage.getItem(storageKey);
         if (saved) {
             this.config = { ...this.config, ...JSON.parse(saved) };
+        }
+
+        try {
+            const resp = await authFetch('/api/user-config');
+            if (resp.ok) {
+                const data = await resp.json();
+                if (data && data.config) {
+                    this.config = { ...this.config, ...data.config };
+                    localStorage.setItem(storageKey, JSON.stringify(this.config));
+                }
+            }
+        } catch (err) {
+            console.error('Error loading config from server:', err);
         }
     }
 
@@ -985,6 +998,15 @@ class NotesApp {
         const storageKey = `notes-app-config-${currentUser}`;
         localStorage.setItem(storageKey, JSON.stringify(this.config));
 
+        // Guardar configuración en el servidor
+        authFetch('/api/user-config', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(this.config)
+        }).catch(err => {
+            console.error('Error saving config on server:', err);
+        });
+
         if (isAdmin) {
             authFetch('/api/update-provider-config', {
                 method: 'POST',
@@ -1002,8 +1024,8 @@ class NotesApp {
         this.showNotification('Configuration saved');
     }
 
-    showConfigModal() {
-        this.loadConfig();
+    async showConfigModal() {
+        await this.loadConfig();
         const tpSelect = document.getElementById('transcription-provider');
         const ppSelect = document.getElementById('postprocess-provider');
 
@@ -1178,6 +1200,15 @@ class NotesApp {
         this.config.translationLanguage = language;
         const storageKey = `notes-app-config-${currentUser}`;
         localStorage.setItem(storageKey, JSON.stringify(this.config));
+
+        // Guardar configuración en el servidor
+        authFetch('/api/user-config', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(this.config)
+        }).catch(err => {
+            console.error('Error saving config on server:', err);
+        });
         this.updateTranslationStyle();
         this.updateAIButtons();
         this.hideTranslationModal();
@@ -1235,6 +1266,15 @@ class NotesApp {
         // Guardar configuración en localStorage
         const storageKey = `notes-app-styles-config-${currentUser}`;
         localStorage.setItem(storageKey, JSON.stringify(this.stylesConfig));
+
+        // Guardar configuración en el servidor
+        authFetch('/api/user-styles', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(this.stylesConfig)
+        }).catch(err => {
+            console.error('Error saving styles on server:', err);
+        });
         
         // Actualizar botones de IA
         this.updateAIButtons();
@@ -1265,6 +1305,20 @@ class NotesApp {
                 }
             });
         }
+
+        // Cargar estilos desde el servidor
+        authFetch('/api/user-styles')
+            .then(resp => resp.ok ? resp.json() : null)
+            .then(data => {
+                if (data && data.styles) {
+                    Object.keys(data.styles).forEach(key => {
+                        this.stylesConfig[key] = data.styles[key];
+                    });
+                }
+            })
+            .catch(err => {
+                console.error('Error loading styles from server:', err);
+            });
     }
 
     addNewStyle() {

--- a/backend.py
+++ b/backend.py
@@ -2936,6 +2936,66 @@ def update_provider_config():
     save_server_config()
     return jsonify({"success": True})
 
+
+@app.route('/api/user-styles', methods=['GET', 'POST'])
+def user_styles():
+    """Load or save custom AI styles for the current user."""
+    username = get_current_username()
+    if not username:
+        return jsonify({"error": "Unauthorized"}), 401
+
+    user_dir = os.path.join(os.getcwd(), 'user_data', username)
+    os.makedirs(user_dir, exist_ok=True)
+    styles_file = os.path.join(user_dir, 'styles.json')
+
+    if request.method == 'GET':
+        if os.path.exists(styles_file):
+            try:
+                with open(styles_file, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                return jsonify({"styles": data})
+            except Exception as e:
+                return jsonify({"error": f"Error reading styles: {str(e)}"}), 500
+        return jsonify({"styles": {}})
+
+    data = request.get_json() or {}
+    try:
+        with open(styles_file, 'w', encoding='utf-8') as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        return jsonify({"success": True})
+    except Exception as e:
+        return jsonify({"error": f"Error saving styles: {str(e)}"}), 500
+
+
+@app.route('/api/user-config', methods=['GET', 'POST'])
+def user_config():
+    """Load or save config settings for the current user."""
+    username = get_current_username()
+    if not username:
+        return jsonify({"error": "Unauthorized"}), 401
+
+    user_dir = os.path.join(os.getcwd(), 'user_data', username)
+    os.makedirs(user_dir, exist_ok=True)
+    config_file = os.path.join(user_dir, 'config.json')
+
+    if request.method == 'GET':
+        if os.path.exists(config_file):
+            try:
+                with open(config_file, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                return jsonify({"config": data})
+            except Exception as e:
+                return jsonify({"error": f"Error reading config: {str(e)}"}), 500
+        return jsonify({"config": {}})
+
+    data = request.get_json() or {}
+    try:
+        with open(config_file, 'w', encoding='utf-8') as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        return jsonify({"success": True})
+    except Exception as e:
+        return jsonify({"error": f"Error saving config: {str(e)}"}), 500
+
 @app.route('/api/list-saved-notes', methods=['GET'])
 def list_saved_notes():
     """Endpoint para listar las notas guardadas en el servidor"""

--- a/backend.py
+++ b/backend.py
@@ -780,7 +780,7 @@ def improve_text_openai(text, improvement_type, model, custom_prompt=None):
     
     # Si se proporciona un prompt personalizado, usarlo directamente
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}",
+        prompt = f"{custom_prompt}\n\n{text}"
     else:
         # Definir prompts según el tipo de mejora (solo para estilos predeterminados)
         prompts = {
@@ -837,7 +837,7 @@ def improve_text_google(text, improvement_type, model, custom_prompt=None):
     
     # Si se proporciona un prompt personalizado, usarlo directamente
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}",
+        prompt = f"{custom_prompt}\n\n{text}"
     else:
         # Definir prompts según el tipo de mejora (solo para estilos predeterminados)
         prompts = {
@@ -886,7 +886,7 @@ def improve_text_openai_stream(text, improvement_type, model, custom_prompt=None
     
     # Si se proporciona un prompt personalizado, usarlo directamente
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}",
+        prompt = f"{custom_prompt}\n\n{text}"
     else:
         # Definir prompts según el tipo de mejora (solo para estilos predeterminados)
         prompts = {
@@ -973,7 +973,7 @@ def improve_text_google_stream(text, improvement_type, model, custom_prompt=None
     
     # Si se proporciona un prompt personalizado, usarlo directamente
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}",
+        prompt = f"{custom_prompt}\n\n{text}"
     else:
         # Definir prompts según el tipo de mejora (solo para estilos predeterminados)
         prompts = {
@@ -1055,7 +1055,7 @@ def improve_text_openrouter(text, improvement_type, model, custom_prompt=None):
     
     # Si se proporciona un prompt personalizado, usarlo directamente
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}",
+        prompt = f"{custom_prompt}\n\n{text}"
     else:
         # Definir prompts según el tipo de mejora (solo para estilos predeterminados)
         prompts = {
@@ -1131,7 +1131,7 @@ def improve_text_openrouter_stream(text, improvement_type, model, custom_prompt=
     
     # Si se proporciona un prompt personalizado, usarlo directamente
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}",
+        prompt = f"{custom_prompt}\n\n{text}"
     else:
         # Definir prompts según el tipo de mejora (solo para estilos predeterminados)
         prompts = {
@@ -1222,7 +1222,7 @@ def improve_text_groq(text, improvement_type, model, custom_prompt=None):
         return jsonify({"error": "Model not specified"}), 400
 
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}",
+        prompt = f"{custom_prompt}\n\n{text}"
     else:
         prompts = {
             'clarity': f"Rewrite the following text in a clearer and more readable way. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking aloud. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
@@ -1277,7 +1277,7 @@ def improve_text_groq_stream(text, improvement_type, model, custom_prompt=None):
         return Response(generate_error(), mimetype='text/event-stream', headers={'Cache-Control': 'no-cache'})
 
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}",
+        prompt = f"{custom_prompt}\n\n{text}"
     else:
         prompts = {
             'clarity': f"Rewrite the following text in a clearer and more readable way. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking aloud. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
@@ -1344,7 +1344,7 @@ def improve_text_lmstudio(text, improvement_type, model, host, port, custom_prom
         return jsonify({"error": "LM Studio host, port and model required"}), 400
 
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}",
+        prompt = f"{custom_prompt}\n\n{text}"
     else:
         prompts = {
             'clarity': f"Rewrite the following text in a clearer and more readable way. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
@@ -1408,7 +1408,7 @@ def improve_text_lmstudio_stream(text, improvement_type, model, host, port, cust
         return Response(generate_error(), mimetype='text/event-stream', headers={'Cache-Control': 'no-cache'})
 
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}",
+        prompt = f"{custom_prompt}\n\n{text}"
     else:
         prompts = {
             'clarity': f"Rewrite the following text in a clearer and more readable way. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
@@ -1470,7 +1470,7 @@ def improve_text_ollama(text, improvement_type, model, host, port, custom_prompt
         return jsonify({"error": "Ollama host, port and model required"}), 400
 
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}",
+        prompt = f"{custom_prompt}\n\n{text}"
     else:
         prompts = {
             'clarity': f"Rewrite the following text in a clearer and more readable way. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the improved text, without additional explanations:\n\n{text}",
@@ -1514,7 +1514,7 @@ def improve_text_ollama_stream(text, improvement_type, model, host, port, custom
         return Response(generate_error(), mimetype='text/event-stream', headers={'Cache-Control': 'no-cache'})
 
     if custom_prompt:
-        prompt = f"{custom_prompt}\n\n{text}",
+        prompt = f"{custom_prompt}\n\n{text}"
     else:
         prompts = {
             'clarity': f"Rewrite the following text in a clearer and more readable way. Remove any interjections or expressions typical of spoken language (mmm, ahhh, eh, um, etc.) and expressions of hesitation when speaking or thinking aloud. Respond ONLY with the improved text, without additional explanations:\n\n{text}",


### PR DESCRIPTION
## Summary
- persist custom AI enhancement styles on backend per-user
- fetch and save styles via `/api/user-styles`
- persist user config settings server-side
- load config from `/api/user-config` when opening config modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687d0704a450832e8c9079692dca99e0