### PR TITLE
Add AI-driven node graph visualization

### DIFF
--- a/backend-api.js
+++ b/backend-api.js
@@ -693,6 +693,24 @@ class BackendAPI {
             throw error;
         }
     }
+
+    async generateNodeGraph(note) {
+        try {
+            const response = await authFetch(`${this.baseUrl}/api/node-graph`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ note })
+            });
+            if (!response.ok) {
+                const err = await response.json();
+                throw new Error(err.error || `HTTP ${response.status}`);
+            }
+            return await response.json();
+        } catch (error) {
+            console.error('Error generating node graph:', error);
+            throw error;
+        }
+    }
 }
 
 // Instancia global del API backend

--- a/index.html
+++ b/index.html
@@ -153,6 +153,9 @@
                         <button class="btn btn--outline btn--sm" id="graph-btn" title="Graph view">
                             <i class="fas fa-project-diagram"></i>&nbsp;Graph
                         </button>
+                        <button class="btn btn--outline btn--sm" id="node-graph-btn" title="Node map">
+                            <i class="fas fa-share-alt"></i>&nbsp;Node Map
+                        </button>
                         <button class="btn btn--outline btn--sm" id="files-btn" title="Files">
                             <i class="fas fa-folder"></i>&nbsp;Files
                         </button>
@@ -351,6 +354,19 @@
                 </button>
                 <button class="btn btn--outline btn--sm" id="download-graph-btn">Download</button>
                 <button class="btn btn--outline btn--sm" id="close-graph-modal">Close</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Node Graph modal -->
+    <div class="modal" id="node-graph-modal">
+        <div class="modal-content modal-content--wide">
+            <div class="modal-body">
+                <div class="node-graph-container" id="node-graph-container"></div>
+                <div class="map-insights" id="map-insights"></div>
+            </div>
+            <div class="modal-actions">
+                <button class="btn btn--outline btn--sm" id="close-node-graph-modal">Close</button>
             </div>
         </div>
     </div>
@@ -869,12 +885,16 @@
         <button class="mobile-tool-btn" data-target="graph-btn" aria-label="Graph">
             <i class="fas fa-project-diagram"></i>
         </button>
+        <button class="mobile-tool-btn" data-target="node-graph-btn" aria-label="Node Map">
+            <i class="fas fa-share-alt"></i>
+        </button>
         <button class="mobile-tool-btn" data-target="files-btn" aria-label="Files">
             <i class="fas fa-folder"></i>
         </button>
     </div>
     </div> <!-- end app-content -->
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="/backend-api.js"></script>
     <script src="/app.js"></script>
 </body>

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ beautifulsoup4
 pyannote.audio
 torchaudio
 numpy
+networkx

--- a/style.css
+++ b/style.css
@@ -2854,6 +2854,29 @@ select.form-control {
     height: auto;
 }
 
+/* Node graph modal */
+.node-graph-container {
+    width: 100%;
+    height: 60vh;
+    margin-bottom: var(--space-16);
+}
+
+.node-graph-container svg {
+    width: 100%;
+    height: 100%;
+}
+
+.map-insights {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-12);
+    color: var(--color-text);
+    max-height: 30vh;
+    overflow-y: auto;
+    white-space: pre-wrap;
+}
+
 /* Ensure graph text is visible in all themes */
 #graph-container svg text {
     fill: var(--color-text);


### PR DESCRIPTION
## Summary
- extend requirements with `networkx`
- implement node graph generation API in backend
- expose new `generateNodeGraph` call in backend-api.js
- add node graph logic and modal handling in app.js
- update index.html with new button, modal and D3 script
- style the node graph modal

## Testing
- `pip install networkx`
- `pip install flask flask-cors requests python-dotenv psycopg[binary] psycopg-pool argon2-cffi mermaid-py markdownify beautifulsoup4 pydub librosa soundfile`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687e1b1be2f4832e8fcc6e71d76c96e0