### PR TITLE
Add Python-based concept graph

### DIFF
--- a/backend-api.js
+++ b/backend-api.js
@@ -693,6 +693,25 @@ class BackendAPI {
             throw error;
         }
     }
+
+    async generateConceptGraph(note) {
+        try {
+            const payload = { note };
+            const response = await authFetch(`${this.baseUrl}/api/concept-graph`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (!response.ok) {
+                const err = await response.json();
+                throw new Error(err.error || `HTTP ${response.status}`);
+            }
+            return await response.json();
+        } catch (error) {
+            console.error('Error generating concept graph:', error);
+            throw error;
+        }
+    }
 }
 
 // Instancia global del API backend

--- a/index.html
+++ b/index.html
@@ -153,6 +153,9 @@
                         <button class="btn btn--outline btn--sm" id="graph-btn" title="Graph view">
                             <i class="fas fa-project-diagram"></i>&nbsp;Graph
                         </button>
+                        <button class="btn btn--outline btn--sm" id="concept-graph-btn" title="Concept map">
+                            <i class="fas fa-network-wired"></i>&nbsp;Concepts
+                        </button>
                         <button class="btn btn--outline btn--sm" id="files-btn" title="Files">
                             <i class="fas fa-folder"></i>&nbsp;Files
                         </button>
@@ -351,6 +354,19 @@
                 </button>
                 <button class="btn btn--outline btn--sm" id="download-graph-btn">Download</button>
                 <button class="btn btn--outline btn--sm" id="close-graph-modal">Close</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Concept graph modal -->
+    <div class="modal" id="concept-graph-modal">
+        <div class="modal-content modal-content--wide">
+            <div class="modal-body">
+                <div class="concept-graph-container" id="concept-graph-container"></div>
+                <pre class="map-insights" id="map-insights"></pre>
+            </div>
+            <div class="modal-actions">
+                <button class="btn btn--outline btn--sm" id="close-concept-graph-modal">Close</button>
             </div>
         </div>
     </div>
@@ -869,12 +885,16 @@
         <button class="mobile-tool-btn" data-target="graph-btn" aria-label="Graph">
             <i class="fas fa-project-diagram"></i>
         </button>
+        <button class="mobile-tool-btn" data-target="concept-graph-btn" aria-label="Concepts">
+            <i class="fas fa-network-wired"></i>
+        </button>
         <button class="mobile-tool-btn" data-target="files-btn" aria-label="Files">
             <i class="fas fa-folder"></i>
         </button>
     </div>
     </div> <!-- end app-content -->
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
     <script src="/backend-api.js"></script>
     <script src="/app.js"></script>
 </body>

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,9 @@ argon2-cffi
 mermaid-py
 markdownify
 beautifulsoup4
+# Graph analysis dependencies
+spacy
+networkx
 # Dependencies for speaker diarization
 pyannote.audio
 torchaudio

--- a/style.css
+++ b/style.css
@@ -2859,6 +2859,22 @@ select.form-control {
     fill: var(--color-text);
 }
 
+.concept-graph-container {
+    width: 100%;
+    height: 60vh;
+    margin-bottom: var(--space-16);
+}
+
+.map-insights {
+    max-height: 20vh;
+    overflow-y: auto;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-12);
+    color: var(--color-text);
+}
+
 .graph-text-output {
     max-height: 40vh;
     overflow-y: auto;

--- a/tests/test_concept_graph.py
+++ b/tests/test_concept_graph.py
@@ -1,0 +1,33 @@
+import ast
+import spacy
+import networkx as nx
+import itertools
+from collections import Counter
+from pathlib import Path
+
+nlp = spacy.load('en_core_web_sm')
+
+source = Path('backend.py').read_text()
+mod = ast.parse(source)
+for node in mod.body:
+    if isinstance(node, ast.FunctionDef) and node.name == 'build_concept_graph':
+        func_code = ast.Module(body=[node], type_ignores=[])
+        compiled = compile(ast.fix_missing_locations(func_code), filename='backend_snippet', mode='exec')
+        ns = {
+            'nlp': nlp,
+            'nx': nx,
+            'itertools': itertools,
+            'Counter': Counter
+        }
+        exec(compiled, ns)
+        build_concept_graph = ns['build_concept_graph']
+        break
+else:
+    raise RuntimeError('Function not found')
+
+
+def test_build_concept_graph_basic():
+    text = 'AI connects ideas. Ideas inspire innovation. Innovation drives progress.'
+    G, cluster_map, insights = build_concept_graph(text)
+    assert insights['total_nodes'] >= 4
+    assert insights['total_links'] > 0


### PR DESCRIPTION
## Summary
- generate concept graph data on backend using spaCy & networkx
- expose `/api/concept-graph` endpoint
- add frontend modal and toolbar button for concept map
- render interactive graph with D3 and show insights
- include unit test for concept graph builder
- update dependencies

## Testing
- `pytest tests/test_concept_graph.py -q`
- `pytest -q` *(fails: missing database & heavy deps)*

------
https://chatgpt.com/codex/tasks/task_e_687e22715630832e8cb132e5b445c6e8