### PR TITLE
Fix Markdown display when uploading PDF

### DIFF
--- a/app.js
+++ b/app.js
@@ -1818,10 +1818,11 @@ class NotesApp {
             if (result.success) {
                 // Replace note content with extracted text
                 const editor = document.getElementById('editor');
-                safeSetInnerHTML(editor, result.text);
-                
+                const htmlContent = this.markdownToHtml(result.text);
+                safeSetInnerHTML(editor, htmlContent);
+
                 // Update current note
-                this.currentNote.content = result.text;
+                this.currentNote.content = htmlContent;
                 this.saveCurrentNote();
                 
                 this.updateFileUploadStatus(fileItem, 'success', 'Content inserted successfully');


### PR DESCRIPTION
## Summary
- convert PDF markdown to HTML when inserting into editor

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_687f24c682fc832e8e6cc894a711a69c