### PR TITLE
Improve concept graph term filtering

### DIFF
--- a/concept_graph.py
+++ b/concept_graph.py
@@ -1021,7 +1021,27 @@ def is_content_word(term, language='english'):
     
     if term in meta_terms:
         return False
-    
+
+    # Additional POS-based filtering to remove pronouns, prepositions,
+    # verbs and adjectives that offer little semantic value. Apply only
+    # to single-word terms to avoid breaking multi-word concepts.
+    if ' ' not in term and term.isalpha():
+        lang = language.lower()
+        if lang in ['english', 'en'] and NLTK_AVAILABLE:
+            try:
+                tokens = nltk.word_tokenize(term)
+                if tokens:
+                    tags = nltk.pos_tag(tokens)
+                    # Keep nouns and proper nouns only
+                    if not all(pos.startswith('NN') for _, pos in tags):
+                        return False
+            except Exception:
+                pass
+        elif lang in ['spanish', 'es', 'español']:
+            # Filter common verb/adverb endings in Spanish
+            if re.search(r'(?:ando|iendo|ado|ada|ados|adas|ido|ida|idos|idas|mente|\b(?:ar|er|ir))$', term):
+                return False
+
     return True
 
 def calculate_term_importance(terms, text, max_sentences=100):

--- a/concept_graph_improved.py
+++ b/concept_graph_improved.py
@@ -142,6 +142,13 @@ def extract_key_terms_improved(text: str, max_text_length: int = 75000) -> Dict[
                     
                     lemmatized = lemmatizer.lemmatize(word)
                     if lemmatized not in stop_words and len(lemmatized) >= 3:
+                        # Keep primarily nouns to avoid pronouns or verbs
+                        try:
+                            tags = nltk.pos_tag([lemmatized])
+                            if tags and not tags[0][1].startswith('NN'):
+                                continue
+                        except Exception:
+                            pass
                         term_freq[lemmatized] += 1
         
         except Exception as e:

--- a/spanish_concept_graph.py
+++ b/spanish_concept_graph.py
@@ -337,6 +337,10 @@ def extract_spanish_terms(text: str, max_text_length: int = 200000) -> Dict[str,
         
         # Lemmatize the word
         lemmatized = simple_spanish_lemmatizer(word)
+
+        # Remove common verb and adjective forms that add little value
+        if re.search(r'(?:ando|iendo|ado|ada|ados|adas|ido|ida|idos|idas|mente|\b(?:ar|er|ir))$', lemmatized):
+            continue
         
         # Additional filtering for Spanish
         if (len(lemmatized) >= 3 and 


### PR DESCRIPTION
## Summary
- refine filtering in concept_graph to skip verbs, pronouns and other low value words
- skip Spanish verb/adverb endings when extracting terms
- use POS tagging in concept_graph_improved to keep only nouns

## Testing
- `PYTHONPATH=. pytest -q tests/test_improved_quality.py::test_improved_quality -s`
- `PYTHONPATH=. pytest -q tests/test_spanish_real.py::test_spanish_with_spanish_text -s`
- `python - <<'PY'
from high_quality_concept_graph import build_high_quality_concept_graph
... (quality check) ...
PY`

------
https://chatgpt.com/codex/tasks/task_e_687f260b6614832ead7f827143606a8f