### PR TITLE
Improve lemmatization for concept graph

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,6 @@ networkx
 nltk
 # For AI-enhanced concept graph
 aiohttp
+# Optional Spanish lemmatization
+spacy
+es_core_news_sm


### PR DESCRIPTION
## Summary
- support Spanish lemmatization via optional `spacy` and fallback rules
- extend Spanish stopwords with comprehensive list
- add several generic verbs to English stopwords
- update requirements with optional spacy model

## Testing
- `python3 quality_test.py` *(fails: quality 16%)*
- `python3 comprehensive_quality_test.py`
- `PYTHONPATH=. python3 tests/test_spanish_real.py`
- `PYTHONPATH=. python3 tests/test_integrated_spanish.py`
- `pytest tests/test_concept_graph.py::test_filtering -q` *(fails: no collectors)*

------
https://chatgpt.com/codex/tasks/task_e_687f4f8b7f9c832e900d413be90d9805