### PR TITLE
Enable Let's Encrypt certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     ffmpeg \
     openssl \
+    certbot \
     && rm -rf /var/lib/apt/lists/*
 
 # Configurar git-lfs
@@ -58,9 +59,8 @@ RUN if [ -f "whisper.cpp-main/build/bin/whisper-cli" ]; then \
     fi
 
 # Configurar nginx
-COPY nginx.conf /etc/nginx/sites-available/default
-RUN rm -f /etc/nginx/sites-enabled/default && \
-    ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/
+COPY nginx.conf.template /etc/nginx/nginx.conf.template
+RUN rm -f /etc/nginx/sites-enabled/default
 
 # Copiar archivos estáticos al directorio que nginx puede servir
 RUN mkdir -p /usr/share/nginx/html && \

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ WhisPad is a transcription and note management tool designed so anyone can turn 
 5. [Installing from the Terminal](#installing-from-the-terminal)
 6. [API Key Configuration](#api-key-configuration)
 7. [Speaker Diarization Setup](#speaker-diarization-setup)
-8. [Usage Guide](#usage-guide)
-9. [Screenshots](#screenshots)
-10. [Contributors](#contributors)
+8. [HTTPS with Let's Encrypt](#https-with-lets-encrypt)
+9. [Usage Guide](#usage-guide)
+10. [Screenshots](#screenshots)
+11. [Contributors](#contributors)
 
 ## Main Features
 - Real-time voice-to-text transcription from the browser.
@@ -101,6 +102,25 @@ If you prefer not to use Docker, you can also run it directly with Python:
    ```
 6. Open `index.html` in your browser or serve the folder with `python -m http.server 5037` and visit `https://localhost:5037`.
 7. Log in with **admin** using the password from `ADMIN_PASSWORD` the first time you access the app.
+
+## HTTPS with Let's Encrypt
+To access WhisPad with a valid HTTPS certificate, provide a public domain and email address.
+Set the variables `LETSENCRYPT_DOMAIN` and `LETSENCRYPT_EMAIL` when starting the container
+and make sure port **80** is reachable from the internet. On first start the
+container will automatically run **certbot** and configure Nginx with the generated
+certificate.
+The certificate is checked on each start and renewed automatically when less than
+30 days remain before expiration.
+
+Example:
+```bash
+LETSENCRYPT_DOMAIN=yourdomain.com \
+LETSENCRYPT_EMAIL=you@example.com \
+docker compose up
+```
+
+The domain must point to your server. If obtaining the certificate fails, the
+app will fall back to a self‑signed certificate.
 
 ## API Key Configuration
 Copy `env.example` to `.env` and add your API keys:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
 
       - BACKEND_PORT=8000
       - CORS_ORIGINS=https://localhost:5037,https://127.0.0.1:5037
+      - LETSENCRYPT_DOMAIN=${LETSENCRYPT_DOMAIN:-}
+      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL:-}
       - DEBUG=False
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
 

--- a/env.example
+++ b/env.example
@@ -16,6 +16,12 @@ HUGGINGFACE_TOKEN=your_huggingface_token_here
 BACKEND_PORT=8000
 CORS_ORIGINS=https://localhost:5037,https://127.0.0.1:5037
 
+# HTTPS configuration (optional)
+# Set these if you want to obtain a Let's Encrypt certificate automatically.
+# The certificate will be renewed on start when less than 30 days remain.
+LETSENCRYPT_DOMAIN=
+LETSENCRYPT_EMAIL=
+
 # Application configuration
 DEBUG=False
 # LM Studio configuration (optional)

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -2,8 +2,8 @@ server {
     listen 5037 ssl;
     server_name localhost;
 
-    ssl_certificate     /etc/nginx/certs/selfsigned.crt;
-    ssl_certificate_key /etc/nginx/certs/selfsigned.key;
+    ssl_certificate     ${SSL_CERT_PATH};
+    ssl_certificate_key ${SSL_KEY_PATH};
     
     # Configuración básica
     client_max_body_size 4G;  # Para subida de archivos de audio y modelos grandes


### PR DESCRIPTION
## Summary
- install certbot in Docker image
- switch nginx config to template with cert path placeholders
- add environment variables for Let's Encrypt to compose file and env example
- update start script to obtain a cert when LETSENCRYPT_* variables are set
- document HTTPS setup in README
- automatically renew Let's Encrypt certificate when less than 30 days remain

## Testing
- `pip install flask markdownify flask_cors requests python-dotenv mermaid-py pydub networkx argon2-cffi psycopg_pool psycopg`
- `DATABASE_URL=postgresql://localhost/test python -m pytest tests/test_integration.py -k test_integration_login -q` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688331f3b700832eb56d1dce373ba3fa