### PR TITLE
Delete study items when removing notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ WhisPad is a transcription and note management tool designed so anyone can turn 
 - Download or upload local (.bin) whisper.cpp models directly from the interface.
 - Upload audio files which are automatically transcribed and stored alongside your notes.
 - Export all notes in a ZIP file with one click.
+- Deleting a note automatically removes its related quizzes and flashcards.
 - Mobile-friendly interface.
 - User login with per-user note folders and admin management tools.
 - Admin has access to all providers and can manage which ones are available for each user.

--- a/app.js
+++ b/app.js
@@ -10530,7 +10530,8 @@ class StudyManager {
                 body: JSON.stringify({
                     content: currentChunk,
                     difficulty: level,
-                    num_questions: 10
+                    num_questions: 10,
+                    note_id: this.currentNote.id
                 })
             });
 
@@ -10616,7 +10617,8 @@ class StudyManager {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     content: currentChunk,
-                    num_cards: 10
+                    num_cards: 10,
+                    note_id: this.currentNote.id
                 })
             });
 
@@ -10853,7 +10855,8 @@ class StudyManager {
                 body: JSON.stringify({
                     content: currentChunk,
                     difficulty: level,
-                    num_questions: 10
+                    num_questions: 10,
+                    note_id: this.currentNote.id
                 })
             });
 

--- a/backend.py
+++ b/backend.py
@@ -4297,17 +4297,27 @@ def delete_note():
                 except Exception as e:
                     print(f"Error leyendo metadatos {filename}: {e}")
                     continue
-        
+
+        # Delete associated study items
+        deleted_count = 0
+        try:
+            from db import delete_study_items_by_note_id
+            deleted_count = delete_study_items_by_note_id(username, note_id)
+        except Exception as e:
+            print(f"Error deleting study items for note {note_id}: {e}")
+
         if deleted_file:
             return jsonify({
                 "success": True,
                 "message": "Nota eliminada correctamente del servidor",
-                "filename": deleted_file
+                "filename": deleted_file,
+                "deleted_study_items": deleted_count
             })
         else:
             return jsonify({
                 "success": True,
-                "message": "Nota no encontrada en el servidor (puede no haberse guardado previamente)"
+                "message": "Nota no encontrada en el servidor (puede no haberse guardado previamente)",
+                "deleted_study_items": deleted_count
             })
         
     except Exception as e:
@@ -6132,6 +6142,7 @@ def generate_quiz():
     
     data = request.get_json() or {}
     note_content = data.get('content', '')
+    note_id = data.get('note_id')
     difficulty = data.get('difficulty', 'medium')
     num_questions = data.get('num_questions', 5)
     
@@ -6309,7 +6320,8 @@ def generate_quiz():
                         item_type='quiz',
                         items=quiz_data['questions'],
                         source_content=note_content,
-                        base_title=base_title
+                        base_title=base_title,
+                        note_id=note_id
                     )
                     
                     # Return the first ID as study_id for compatibility
@@ -6349,6 +6361,7 @@ def generate_flashcards():
     
     data = request.get_json() or {}
     note_content = data.get('content', '')
+    note_id = data.get('note_id')
     num_cards = data.get('num_cards', 10)
     
     if not note_content:
@@ -6514,7 +6527,8 @@ def generate_flashcards():
                         item_type='flashcards',
                         items=flashcards_data['flashcards'],
                         source_content=note_content,
-                        base_title=base_title
+                        base_title=base_title,
+                        note_id=note_id
                     )
                     
                     # Return the first ID as study_id for compatibility

--- a/tests/test_delete_note_items.py
+++ b/tests/test_delete_note_items.py
@@ -1,0 +1,54 @@
+import os
+import json
+import pytest
+from backend import app, HASHER
+from db import pool, init_db, create_user, save_individual_study_items
+
+os.environ.setdefault("ADMIN_PASSWORD", "secret")
+
+@pytest.fixture(autouse=True)
+def setup_env(tmp_path):
+    init_db()
+    with pool.connection() as conn:
+        conn.execute('DELETE FROM users')
+        conn.execute('DELETE FROM study_items')
+        conn.commit()
+    create_user('admin', HASHER.hash('secret'), True, [], [])
+
+    # Prepare note files
+    notes_dir = tmp_path / 'saved_notes' / 'admin'
+    notes_dir.mkdir(parents=True)
+    note_id = 'testnote'
+    (notes_dir / 'note.md').write_text('# Title\nContent')
+    (notes_dir / 'note.md.meta').write_text(json.dumps({'id': note_id, 'title': 'note'}))
+
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    yield {'note_id': note_id}
+    os.chdir(old_cwd)
+    with pool.connection() as conn:
+        conn.execute('DELETE FROM users')
+        conn.execute('DELETE FROM study_items')
+        conn.commit()
+
+
+def test_delete_note_removes_study_items(setup_env):
+    note_id = setup_env['note_id']
+    # create a study item linked to note
+    save_individual_study_items('admin', 'quiz', [{'question': 'Q1', 'answers': ['A'], 'correct_answer': 0}], source_content='Content', base_title='Quiz', note_id=note_id)
+
+    client = app.test_client()
+    resp = client.post('/api/login', json={'username': 'admin', 'password': 'secret'})
+    token = resp.get_json()['token']
+
+    resp = client.post('/api/delete-note', json={'id': note_id}, headers={'Authorization': token})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['success'] is True
+    assert data.get('deleted_study_items', 0) >= 1
+    # verify no study items remain
+    with pool.connection() as conn:
+        cur = conn.execute('SELECT COUNT(*) FROM study_items WHERE note_id=%s', [note_id])
+        count = cur.fetchone()[0]
+    assert count == 0
+


### PR DESCRIPTION
## Summary
- add bullet about note deletion effect
- track note_id in study items
- support removing quizzes/flashcards when note deleted
- send note_id when generating quizzes and flashcards
- test deletion of related study items

## Testing
- `pytest tests/test_delete_note_items.py -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_688331ba88bc832eb7f6269ff5864a63