### PR TITLE
Add backend-generated PDF export

### DIFF
--- a/index.html
+++ b/index.html
@@ -1497,7 +1497,6 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
-    <script src="https://cdn.jsdelivr.net/npm/html2pdf.js@0.9.2/dist/html2pdf.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/html-docx-js/dist/html-docx.js"></script>
     <script src="/backend-api.js"></script>
     <script src="/app.js"></script>

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ mermaid-py
 markdownify
 beautifulsoup4
 markitdown[pdf]
+WeasyPrint
 # Dependencies for speaker diarization
 pyannote.audio
 torchaudio


### PR DESCRIPTION
## Summary
- implement PDF export server-side using WeasyPrint
- switch frontend export to call `/api/export-pdf`
- remove unused html2pdf script
- add WeasyPrint to requirements

## Testing
- `pip install -q WeasyPrint`
- `pytest -q` *(fails: DATABASE_URL environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_6883556de964832ea6b2aec7911f5564