### PR TITLE
Add keep original option

### DIFF
--- a/app.js
+++ b/app.js
@@ -8177,9 +8177,23 @@ class NotesApp {
             tempSpan.style.border = '1px dashed #1976d2';
             tempSpan.textContent = '⏳ Improving...';
             
-            // Reemplazar el texto seleccionado con el elemento temporal
-            rangeToReplace.deleteContents();
-            rangeToReplace.insertNode(tempSpan);
+            const keepOriginal = document.getElementById('keep-original')?.checked;
+
+            if (!keepOriginal) {
+                // Reemplazar el texto seleccionado con el elemento temporal
+                rangeToReplace.deleteContents();
+            } else {
+                // Insert after the selected text
+                rangeToReplace.collapse(false);
+                const fragment = document.createDocumentFragment();
+                fragment.appendChild(document.createElement('br'));
+                fragment.appendChild(document.createElement('br'));
+                fragment.appendChild(tempSpan);
+                rangeToReplace.insertNode(fragment);
+            }
+            if (!keepOriginal) {
+                rangeToReplace.insertNode(tempSpan);
+            }
             
             // Limpiar selección visual pero mantener referencia
             const selection = window.getSelection();

--- a/index.html
+++ b/index.html
@@ -211,6 +211,11 @@
                         <button class="btn btn--outline btn--sm" id="undo-ai-btn" title="Undo last AI change" disabled>
                             <span class="ai-icon">↶</span>&nbsp;Undo
                         </button>
+                        <label class="checkbox-label keep-original-label">
+                            <input type="checkbox" id="keep-original">
+                            <span class="checkmark"></span>
+                            Keep original
+                        </label>
                     </div>
                 </div>
             </div>

--- a/note-transcribe-ai/app.js
+++ b/note-transcribe-ai/app.js
@@ -827,9 +827,21 @@ class NotesApp {
             selection.removeAllRanges();
             selection.addRange(this.selectedRange);
             
-            // Reemplazar texto seleccionado
-            this.selectedRange.deleteContents();
-            this.selectedRange.insertNode(document.createTextNode(improvedText));
+            const keepOriginal = document.getElementById('keep-original')?.checked;
+
+            if (!keepOriginal) {
+                // Reemplazar texto seleccionado
+                this.selectedRange.deleteContents();
+                this.selectedRange.insertNode(document.createTextNode(improvedText));
+            } else {
+                const range = this.selectedRange.cloneRange();
+                range.collapse(false);
+                const fragment = document.createDocumentFragment();
+                fragment.appendChild(document.createElement('br'));
+                fragment.appendChild(document.createElement('br'));
+                fragment.appendChild(document.createTextNode(improvedText));
+                range.insertNode(fragment);
+            }
             
             // Limpiar selección
             selection.removeAllRanges();

--- a/note-transcribe-ai/index.html
+++ b/note-transcribe-ai/index.html
@@ -79,6 +79,11 @@
                             <span class="ai-icon">↶</span>
                             Undo
                         </button>
+                        <label class="checkbox-label keep-original-label">
+                            <input type="checkbox" id="keep-original">
+                            <span class="checkmark"></span>
+                            Keep original
+                        </label>
                     </div>
                 </div>
             </div>

--- a/note-transcribe-ai/style.css
+++ b/note-transcribe-ai/style.css
@@ -872,6 +872,14 @@ select.form-control {
     padding: var(--space-6) var(--space-12);
 }
 
+.ai-controls .keep-original-label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+    font-size: var(--font-size-xs);
+    margin-bottom: 0;
+}
+
 .ai-icon {
     font-size: var(--font-size-sm);
 }

--- a/style.css
+++ b/style.css
@@ -1455,6 +1455,14 @@ select.form-control {
     padding: var(--space-6) var(--space-12);
 }
 
+.ai-controls .keep-original-label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+    font-size: var(--font-size-xs);
+    margin-bottom: 0;
+}
+
 .ai-icon {
     font-size: var(--font-size-sm);
 }


### PR DESCRIPTION
## Summary
- add 'Keep original' checkbox to AI style controls
- keep original text when checkbox selected
- style the new checkbox

## Testing
- `pytest -q` *(fails: No module named 'mermaid')*

------
https://chatgpt.com/codex/tasks/task_e_68835ae04080832eae9830f91efaad11