### PR TITLE
Ensure AI enhancements end with blank lines

### DIFF
--- a/app.js
+++ b/app.js
@@ -8182,6 +8182,11 @@ class NotesApp {
             if (!keepOriginal) {
                 // Reemplazar el texto seleccionado con el elemento temporal
                 rangeToReplace.deleteContents();
+                const fragment = document.createDocumentFragment();
+                fragment.appendChild(tempSpan);
+                fragment.appendChild(document.createElement('br'));
+                fragment.appendChild(document.createElement('br'));
+                rangeToReplace.insertNode(fragment);
             } else {
                 // Insert after the selected text
                 rangeToReplace.collapse(false);
@@ -8189,10 +8194,9 @@ class NotesApp {
                 fragment.appendChild(document.createElement('br'));
                 fragment.appendChild(document.createElement('br'));
                 fragment.appendChild(tempSpan);
+                fragment.appendChild(document.createElement('br'));
+                fragment.appendChild(document.createElement('br'));
                 rangeToReplace.insertNode(fragment);
-            }
-            if (!keepOriginal) {
-                rangeToReplace.insertNode(tempSpan);
             }
             
             // Limpiar selección visual pero mantener referencia

--- a/note-transcribe-ai/app.js
+++ b/note-transcribe-ai/app.js
@@ -832,7 +832,11 @@ class NotesApp {
             if (!keepOriginal) {
                 // Reemplazar texto seleccionado
                 this.selectedRange.deleteContents();
-                this.selectedRange.insertNode(document.createTextNode(improvedText));
+                const fragment = document.createDocumentFragment();
+                fragment.appendChild(document.createTextNode(improvedText));
+                fragment.appendChild(document.createElement('br'));
+                fragment.appendChild(document.createElement('br'));
+                this.selectedRange.insertNode(fragment);
             } else {
                 const range = this.selectedRange.cloneRange();
                 range.collapse(false);
@@ -840,6 +844,8 @@ class NotesApp {
                 fragment.appendChild(document.createElement('br'));
                 fragment.appendChild(document.createElement('br'));
                 fragment.appendChild(document.createTextNode(improvedText));
+                fragment.appendChild(document.createElement('br'));
+                fragment.appendChild(document.createElement('br'));
                 range.insertNode(fragment);
             }
             


### PR DESCRIPTION
## Summary
- add `<br>` tags after AI enhancement text in the main app
- do the same in the simpler transcription app

## Testing
- `pytest tests/test_auth.py::test_login_ok -q` *(fails: ModuleNotFoundError: No module named 'pydub')*

------
https://chatgpt.com/codex/tasks/task_e_6883600aaac8832e974961108a1d85b0