### PR TITLE
Fix header actions not restored after resizing

### DIFF
--- a/app.js
+++ b/app.js
@@ -339,16 +339,8 @@ class NotesApp {
                 currentMobileContainer.style.display = 'flex';
             } else {
                 buttons.forEach(btn => {
-                    if (btn && btn.parentNode !== currentHeaderActions && document.body.contains(btn) && currentHeaderActions.contains(currentHamburger)) {
-                        try {
-                            currentHeaderActions.insertBefore(btn, currentHamburger);
-                        } catch (error) {
-                            console.warn('Could not move button back to header:', error);
-                            // Fallback: append to header actions if insertBefore fails
-                            if (btn.parentNode !== currentHeaderActions) {
-                                currentHeaderActions.appendChild(btn);
-                            }
-                        }
+                    if (btn && btn.parentNode !== currentHeaderActions && document.body.contains(btn)) {
+                        currentHeaderActions.appendChild(btn);
                     }
                 });
                 currentMobileContainer.style.display = 'none';


### PR DESCRIPTION
## Summary
- ensure responsive header buttons are reinserted into the desktop header on resize

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_cors')*

------
https://chatgpt.com/codex/tasks/task_e_688361df5cdc832ebf0584f762788e46