### PR TITLE
Fix saved questions modal trigger

### DIFF
--- a/app.js
+++ b/app.js
@@ -10606,7 +10606,7 @@ class StudyManager {
 
         // Saved items modal buttons
         document.getElementById('open-saved-questions-btn').addEventListener('click', () => {
-            this.showSavedQuestions();
+            this.showSavedQuizzes();
         });
         document.getElementById('open-saved-flashcards-btn').addEventListener('click', () => {
             this.showSavedFlashcards();


### PR DESCRIPTION
## Summary
- fix misnamed `showSavedQuestions` call

## Testing
- `pytest -k '' -q` *(fails: ModuleNotFoundError for networkx, flask, requests, aiohttp, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68836517a75c832eb46d43a9e1ccc294