### PR TITLE
fix: keep focus mode AI toolbar visible

### DIFF
--- a/style.css
+++ b/style.css
@@ -5247,6 +5247,8 @@ select.form-control {
     margin: 0 auto;
     width: 100%;
     gap: var(--space-16);
+    overflow-y: auto;
+    min-height: 0;
 }
 
 .focus-editor-content {
@@ -5286,6 +5288,9 @@ select.form-control {
     box-shadow: var(--shadow-sm);
     overflow-x: auto;
     white-space: nowrap;
+    position: sticky;
+    bottom: 0;
+    z-index: 10;
 }
 
 .focus-ai-enhancement-toolbar::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- make focus mode editor scrollable and keep AI toolbar at the bottom

## Testing
- `pytest` *(fails: DATABASE_URL environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68915140b7b8832ebc8a68058255dcb6