### PR TITLE
feat: list OpenRouter paid models

### DIFF
--- a/app.js
+++ b/app.js
@@ -9811,7 +9811,7 @@ class NotesApp {
         postprocessModelSelect.appendChild(placeholder);
         
         // Definir modelos por proveedor
-        const openrouterModels = [
+        const baseOpenrouterModels = [
             { value: 'google/gemma-3-27b-it:free', text: 'Gemma 3 27B IT (Free)' },
             { value: 'google/gemini-2.0-flash-exp:free', text: 'Gemini 2.0 Flash Exp (Free)' },
             { value: 'meta-llama/llama-4-maverick:free', text: 'Llama 4 Maverick (Free)' },
@@ -9821,7 +9821,14 @@ class NotesApp {
             { value: 'mistralai/mistral-small-3.1-24b-instruct:free', text: 'Mistral Small 3.1 24B (Free)' },
             { value: 'moonshotai/kimi-k2:free', text: 'Kimi K2 (Free)' }
         ];
+        const openrouterModels = [...baseOpenrouterModels];
         if (this.config.showOpenRouterPaidModels) {
+            baseOpenrouterModels.forEach(m => {
+                openrouterModels.push({
+                    value: m.value.replace(':free', ''),
+                    text: m.text.replace(' (Free)', ' (Paid)')
+                });
+            });
             openrouterModels.push(
                 { value: 'openai/gpt-oss-20b', text: 'GPT-OSS 20B (OpenAI)' },
                 { value: 'openai/gpt-oss-120b', text: 'GPT-OSS 120B (OpenAI)' }

--- a/backend.py
+++ b/backend.py
@@ -159,7 +159,9 @@ OPENROUTER_FREE_MODELS = [
     "moonshotai/kimi-k2:free",
 ]
 
-OPENROUTER_PAID_MODELS = [
+# Paid models include all non-free variants of the above plus
+# additional explicitly paid-only models.
+OPENROUTER_PAID_MODELS = [model.replace(":free", "") for model in OPENROUTER_FREE_MODELS] + [
     "openai/gpt-oss-20b",
     "openai/gpt-oss-120b",
 ]

--- a/tests/test_openrouter_models.py
+++ b/tests/test_openrouter_models.py
@@ -1,0 +1,7 @@
+import pytest
+from backend import OPENROUTER_FREE_MODELS, OPENROUTER_PAID_MODELS
+
+def test_paid_models_include_free_variants():
+    for free_model in OPENROUTER_FREE_MODELS:
+        paid_variant = free_model.replace(':free', '')
+        assert paid_variant in OPENROUTER_PAID_MODELS


### PR DESCRIPTION
## Summary
- duplicate OpenRouter free models as paid variants on the front-end
- generate paid model list on the back-end using non-free variants
- test that paid models include free counterparts

## Testing
- `DATABASE_URL=postgresql://localhost/test PYTHONPATH=. pytest tests/test_openrouter_models.py -q` *(fails: couldn't get a connection)*

------
https://chatgpt.com/codex/tasks/task_e_68929bc690a0832eab7f7e82593d8471